### PR TITLE
Fixed visual bug on Add A Character button in campaign page

### DIFF
--- a/src/features/campaign-sheet/components/AddCharacterDialog.tsx
+++ b/src/features/campaign-sheet/components/AddCharacterDialog.tsx
@@ -78,7 +78,12 @@ export function AddCharacterDialog(props: AddCharacterDialogProps) {
         {Object.keys(characters).length > 0 && (
           <Divider sx={{ my: 3 }}>OR</Divider>
         )}
-        <Box display={"flex"} alignItems={"center"} justifyContent={"center"}>
+        <Box
+          display={"flex"}
+          alignItems={"center"}
+          justifyContent={"center"}
+          mt={2}
+        >
           <Button
             variant={"contained"}
             component={Link}


### PR DESCRIPTION
Came across this if you try to add a character to a campaign without having any characters created. 

![iron-add_char_bug](https://user-images.githubusercontent.com/96504457/216845868-ccb02b7f-0a46-4ea2-9c68-5bec81a85aab.png)

I just added a margin-top and it looks like it works fine. 

![image](https://user-images.githubusercontent.com/96504457/216845954-0abb1256-776b-49b0-8507-62c684914f7c.png)

And double checking that it looks good with characters:

![image](https://user-images.githubusercontent.com/96504457/216846006-e8b581c7-099b-4bc6-a84a-8fc334d5f22e.png)
