### PR TITLE
Highlighting "1" in action rolls

### DIFF
--- a/src/providers/DieRollProvider/RollSnackbar/StatRollSnackbar.tsx
+++ b/src/providers/DieRollProvider/RollSnackbar/StatRollSnackbar.tsx
@@ -1,4 +1,4 @@
-import { Box, ButtonBase, Card, Divider, Typography } from "@mui/material";
+import { Box, ButtonBase, Card, Divider, Typography, useTheme } from "@mui/material";
 import { ROLL_RESULT, StatRoll } from "types/DieRolls.type";
 import { D6Icon } from "assets/D6Icon";
 import { D10Icon } from "assets/D10Icon";
@@ -22,8 +22,15 @@ export interface StatRollSnackbarProps {
 
 export function StatRollSnackbar(props: StatRollSnackbarProps) {
   const { roll, clearRoll, expanded } = props;
+  const theme = useTheme();
 
   const rollTotal = roll.action + (roll.modifier ?? 0) + (roll.adds ?? 0);
+
+  let rollActionColor = theme.palette.grey[200];
+
+  if (roll.action === 1){
+    rollActionColor = theme.palette.warning.light;
+  }
 
   return (
     <Card
@@ -57,8 +64,10 @@ export function StatRollSnackbar(props: StatRollSnackbarProps) {
               justifyContent={"space-between"}
             >
               <D6Icon />
-              <Typography ml={1} color={(theme) => theme.palette.grey[200]}>
+              <Typography ml={1} color={rollActionColor}>
                 {roll.action}
+              </Typography>
+              <Typography ml={1} color={(theme) => theme.palette.grey[200]}>
                 {roll.modifier ? ` + ${roll.modifier}` : ""}
                 {roll.adds ? ` + ${roll.adds}` : ""}
                 {roll.modifier || roll.adds
@@ -109,6 +118,15 @@ export function StatRollSnackbar(props: StatRollSnackbarProps) {
               fontFamily={(theme) => theme.fontFamilyTitle}
             >
               Doubles
+            </Typography>
+          )}
+          {roll.action === 1 && (
+            <Typography
+              color={(theme) => theme.palette.grey[200]}
+              variant={"caption"}
+              fontFamily={(theme) => theme.fontFamilyTitle}
+            >
+              Natural 1
             </Typography>
           )}
         </Box>

--- a/src/providers/DieRollProvider/RollSnackbar/StatRollSnackbar.tsx
+++ b/src/providers/DieRollProvider/RollSnackbar/StatRollSnackbar.tsx
@@ -26,10 +26,16 @@ export function StatRollSnackbar(props: StatRollSnackbarProps) {
 
   const rollTotal = roll.action + (roll.modifier ?? 0) + (roll.adds ?? 0);
 
-  let rollActionColor = theme.palette.grey[200];
+  let rollActionBorder = "none";
+  let rollActionPadding = "0";
+  let rollActionBorderRadius = "0";
+  let rollActionMarginRight = "-4px";
 
   if (roll.action === 1){
-    rollActionColor = theme.palette.warning.light;
+    rollActionBorder = "1px solid " + theme.palette.primary.light;
+    rollActionBorderRadius = "25%";
+    rollActionPadding = "0px 5px 0 4px";
+    rollActionMarginRight = "-6px";
   }
 
   return (
@@ -64,7 +70,13 @@ export function StatRollSnackbar(props: StatRollSnackbarProps) {
               justifyContent={"space-between"}
             >
               <D6Icon />
-              <Typography ml={1} color={rollActionColor}>
+              <Typography ml={1} 
+                color={(theme) => theme.palette.grey[200]}
+                border={rollActionBorder}
+                borderRadius={rollActionBorderRadius}
+                padding={rollActionPadding}
+                marginRight={rollActionMarginRight}
+              >
                 {roll.action}
               </Typography>
               <Typography ml={1} color={(theme) => theme.palette.grey[200]}>


### PR DESCRIPTION
Closes #285 
Closes #282 

I added the `theme.palette.warning.light` color to the `roll.action` result whent it's a 1 and added a text saying "Natural 1" under the `actionResultLabel` (same kind as the "Doubles" one).

If you'd like something different, say it and I"ll change ;)