### PR TITLE
feat(rolls): #360 Allow deleting Rolls from notes

### DIFF
--- a/src/api-calls/game-log/removeLog.ts
+++ b/src/api-calls/game-log/removeLog.ts
@@ -17,8 +17,8 @@ export const removeLog = createApiFunction<
     }
 
     const docRef = characterId
-      ? getCharacterGameLogDocument(characterId, logId)
-      : getCampaignGameLogDocument(campaignId as string, logId);
+      ? getCampaignGameLogDocument(campaignId as string, logId)
+      : getCharacterGameLogDocument(characterId as string, logId);
 
     deleteDoc(docRef)
       .then(() => {

--- a/src/api-calls/game-log/removeLog.ts
+++ b/src/api-calls/game-log/removeLog.ts
@@ -1,0 +1,29 @@
+import { createApiFunction } from "api-calls/createApiFunction";
+import { deleteDoc } from "firebase/firestore";
+import {
+  getCampaignGameLogDocument,
+  getCharacterGameLogDocument,
+} from "./_getRef";
+
+export const removeLog = createApiFunction<
+  { campaignId?: string; characterId?: string; logId: string },
+  void
+>((params) => {
+  const { campaignId, characterId, logId } = params;
+
+  return new Promise((resolve, reject) => {
+    if (!characterId && !campaignId) {
+      reject(new Error("Either campaign or character ID must be defined."));
+    }
+
+    const docRef = characterId
+      ? getCharacterGameLogDocument(characterId, logId)
+      : getCampaignGameLogDocument(campaignId as string, logId);
+
+    deleteDoc(docRef)
+      .then(() => {
+        resolve();
+      })
+      .catch(reject);
+  });
+}, "Failed to delete roll.");

--- a/src/components/features/charactersAndCampaigns/RollDisplay/NormalRollActions.tsx
+++ b/src/components/features/charactersAndCampaigns/RollDisplay/NormalRollActions.tsx
@@ -9,6 +9,7 @@ import { useRef, useState } from "react";
 import MoreIcon from "@mui/icons-material/MoreHoriz";
 import CopyIcon from "@mui/icons-material/CopyAll";
 import RerollIcon from "@mui/icons-material/Casino";
+import BackspaceIcon from '@mui/icons-material/Backspace';
 import MomentumIcon from "@mui/icons-material/Whatshot";
 import { useSnackbar } from "providers/SnackbarProvider";
 import { convertRollToClipboard } from "./clipboardFormatter";
@@ -50,11 +51,21 @@ export function NormalRollActions(props: NormalRollActionsProps) {
   const characterId = useStore(
     (store) => store.characters.currentCharacter.currentCharacterId
   );
+  const campaignId = useStore((store) => store.campaigns.currentCampaign.currentCampaignId);
   const momentum = useStore(
     (store) => store.characters.currentCharacter.currentCharacter?.momentum ?? 0
   );
   const momentumResetValue = useStore(
     (store) => store.characters.currentCharacter.momentumResetValue
+  );
+  const isGM = useStore(
+    (store) =>
+      store.campaigns.currentCampaign.currentCampaign?.gmIds?.includes(
+        store.auth.uid
+      ) ?? false
+  );
+  const removeLog = useStore(
+    (store) => store.gameLog.removeRoll
   );
 
   const updateRoll = useStore((store) => store.gameLog.updateRoll);
@@ -196,6 +207,20 @@ export function NormalRollActions(props: NormalRollActionsProps) {
                 <ListItemText>Burn Momentum</ListItemText>
               </MenuItem>
             )}
+          {(!campaignId || isGM && !characterId) && (
+            <MenuItem
+              onClick={(evt) => {
+                evt.stopPropagation();
+                setIsMenuOpen(false);
+                removeLog(rollId);
+              }}
+            >
+              <ListItemIcon>
+                <BackspaceIcon />
+              </ListItemIcon>
+              <ListItemText>Delete Roll</ListItemText>
+            </MenuItem>
+          )}
         </Menu>
       )}
       {roll.type === ROLL_TYPE.STAT && (

--- a/src/components/features/charactersAndCampaigns/RollDisplay/NormalRollActions.tsx
+++ b/src/components/features/charactersAndCampaigns/RollDisplay/NormalRollActions.tsx
@@ -207,7 +207,7 @@ export function NormalRollActions(props: NormalRollActionsProps) {
                 <ListItemText>Burn Momentum</ListItemText>
               </MenuItem>
             )}
-          {(!campaignId || isGM && !characterId) && (
+          {(!campaignId || isGM) && (
             <MenuItem
               onClick={(evt) => {
                 evt.stopPropagation();

--- a/src/stores/gameLog/gameLog.slice.ts
+++ b/src/stores/gameLog/gameLog.slice.ts
@@ -2,6 +2,7 @@ import { CreateSliceType } from "stores/store.type";
 import { GameLogSlice } from "./gameLog.slice.type";
 import { addRoll } from "api-calls/game-log/addRoll";
 import { defaultGameLogSlice } from "./gameLog.slice.default";
+import { removeLog } from "api-calls/game-log/removeLog";
 import { updateLog } from "api-calls/game-log/updateLog";
 import { listenToLogs } from "api-calls/game-log/listenToLogs";
 
@@ -31,6 +32,20 @@ export const createGameLogSlice: CreateSliceType<GameLogSlice> = (
     }
 
     return updateLog({ characterId, campaignId, logId: id, log: roll });
+  },
+  removeRoll: (id) => {
+    const campaignId = getState().campaigns.currentCampaign.currentCampaignId;
+    const characterId =
+      getState().characters.currentCharacter.currentCharacterId;
+
+    if (!characterId && !campaignId) {
+      return new Promise((res, reject) =>
+        reject("Either character or campaign Id must be defined.")
+      );
+    }
+
+    return removeLog({ characterId, campaignId, logId: id });
+
   },
 
   loadMoreLogs: () => {

--- a/src/stores/gameLog/gameLog.slice.type.ts
+++ b/src/stores/gameLog/gameLog.slice.type.ts
@@ -14,7 +14,8 @@ export interface GameLogSliceActions {
     roll: Roll;
   }) => Promise<string>;
   updateRoll: (id: string, roll: Roll) => Promise<void>;
-
+  removeRoll: (id: string) => Promise<void>;
+  
   loadMoreLogs: () => void;
   subscribe: (params: {
     campaignId?: string;


### PR DESCRIPTION
This PR adds the feature of removing Roll logs.
It allows removing the Rolls in two scenarios:

1. Identified as GM and within Campaign/GM Screen/Notes, users are able to delete Rolls from any character; 
<img width="1148" alt="image" src="https://github.com/scottbenton/Iron-Fellowship_and_Crew-Link/assets/39792862/1d11507b-cb9f-4ef0-a81c-47bf9adac82d">

2. Not identified as a GM, users can delete their own Rolls when accessing Notes, but only if the Character is not assigned to a Campaign.

_Character on a Campaign_
<img width="1506" alt="image" src="https://github.com/scottbenton/Iron-Fellowship_and_Crew-Link/assets/39792862/742bf31f-9924-446a-bf93-05e14a57f9e9">

_Character not on a Campaign_
<img width="1496" alt="image" src="https://github.com/scottbenton/Iron-Fellowship_and_Crew-Link/assets/39792862/7619f44a-bd58-441c-bcd6-2f4ba40e8e64">
