### PR TITLE
[codex] Add shared Datasworn collection filter

### DIFF
--- a/src/components/features/charactersAndCampaigns/LinkedDialog/LinkedDialogContent/OracleDialogContent/OracleCollection.tsx
+++ b/src/components/features/charactersAndCampaigns/LinkedDialog/LinkedDialogContent/OracleDialogContent/OracleCollection.tsx
@@ -21,7 +21,6 @@ export function OracleCollection(props: OracleCollectionProps) {
       collections={collections}
       oracles={oracles}
       visibleCollections={{ [collection._id]: CATEGORY_VISIBILITY.ALL }}
-      enhancesCollections={{}}
       visibleOracles={{}}
     />
   );

--- a/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.test.ts
+++ b/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.test.ts
@@ -1,0 +1,35 @@
+import { Datasworn } from "@datasworn/core";
+import { describe, expect, it } from "vitest";
+import { getMoveIdsForCategory } from "./moveCategoryUtils";
+
+describe("getMoveIdsForCategory", () => {
+  it("uses the category contents without appending enhancing categories again", () => {
+    const baseMove = {
+      _id: "move:classic/combat/strike",
+      type: "move",
+      name: "Strike",
+      roll_type: "no_roll",
+    } as Datasworn.Move;
+    const enhancedMove = {
+      _id: "move:homebrew/combat/custom",
+      type: "move",
+      name: "Custom Move",
+      roll_type: "no_roll",
+    } as Datasworn.Move;
+
+    const category = {
+      _id: "move_category:classic/combat",
+      type: "move_category",
+      name: "Combat",
+      contents: {
+        strike: baseMove,
+        custom: enhancedMove,
+      },
+    } as unknown as Datasworn.MoveCategory;
+
+    expect(getMoveIdsForCategory(category)).toEqual([
+      "move:classic/combat/strike",
+      "move:homebrew/combat/custom",
+    ]);
+  });
+});

--- a/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.tsx
+++ b/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.tsx
@@ -4,29 +4,26 @@ import { CollapsibleSectionHeader } from "../CollapsibleSectionHeader";
 import { CATEGORY_VISIBILITY } from "./useFilterMoves";
 import { Datasworn } from "@datasworn/core";
 import { Move } from "./Move";
+import { getMoveIdsForCategory } from "./moveCategoryUtils";
 
 export interface MoveCategoryProps {
   category: Datasworn.MoveCategory;
-  categories: Record<string, Datasworn.MoveCategory>;
   moveMap: Record<string, Datasworn.Move>;
   openMove: (move: Datasworn.Move) => void;
   forceOpen?: boolean;
   visibleCategories: Record<string, CATEGORY_VISIBILITY>;
   visibleMoves: Record<string, boolean>;
   shouldExpandLocally?: boolean;
-  enhancesCollections: Record<string, string[]>;
 }
 
 export function MoveCategory(props: MoveCategoryProps) {
   const {
     category,
-    categories,
     moveMap,
     openMove,
     forceOpen,
     visibleCategories,
     visibleMoves,
-    enhancesCollections,
     shouldExpandLocally,
   } = props;
 
@@ -34,26 +31,7 @@ export function MoveCategory(props: MoveCategoryProps) {
 
   const isExpandedOrForced = isExpanded || forceOpen;
 
-  const enhancingCollectionIds = enhancesCollections[category._id];
-
-  const contents = category.contents;
-
-  const moveIds = useMemo(() => {
-    const moveIds = Object.values(contents ?? {}).map((move) => move._id);
-
-    (enhancingCollectionIds ?? []).forEach((enhancesId) => {
-      const enhancingCollection = categories[enhancesId];
-      if (enhancingCollection) {
-        moveIds.push(
-          ...Object.values(enhancingCollection.contents ?? {}).map(
-            (move) => move._id,
-          ),
-        );
-      }
-    });
-
-    return moveIds;
-  }, [contents, categories, enhancingCollectionIds]);
+  const moveIds = useMemo(() => getMoveIdsForCategory(category), [category]);
 
   if (visibleCategories[category._id] === CATEGORY_VISIBILITY.HIDDEN) {
     return null;

--- a/src/components/features/charactersAndCampaigns/MovesSection/MovesSection.tsx
+++ b/src/components/features/charactersAndCampaigns/MovesSection/MovesSection.tsx
@@ -21,7 +21,6 @@ export function MovesSection(props: MovesSectionProps) {
     visibleMoveIds,
     isSearchActive,
     isEmpty,
-    enhancesCollections,
   } = useFilterMoves();
 
   const openDialog = useStore((store) => store.appState.openDialog);
@@ -67,7 +66,6 @@ export function MovesSection(props: MovesSectionProps) {
             <MoveCategory
               key={index}
               category={moveCategories[categoryId]}
-              categories={moveCategories}
               moveMap={moveMap}
               openMove={(move) => {
                 openDialog(move._id);
@@ -76,7 +74,6 @@ export function MovesSection(props: MovesSectionProps) {
               visibleCategories={visibleMoveCategoryIds}
               visibleMoves={visibleMoveIds}
               shouldExpandLocally={shouldExpandLocally}
-              enhancesCollections={enhancesCollections}
             />
           ))
         ) : (

--- a/src/components/features/charactersAndCampaigns/MovesSection/moveCategoryUtils.ts
+++ b/src/components/features/charactersAndCampaigns/MovesSection/moveCategoryUtils.ts
@@ -1,0 +1,5 @@
+import { Datasworn } from "@datasworn/core";
+
+export function getMoveIdsForCategory(category: Datasworn.MoveCategory) {
+  return Object.values(category.contents ?? {}).map((move) => move._id);
+}

--- a/src/components/features/charactersAndCampaigns/MovesSection/useFilterMoves.ts
+++ b/src/components/features/charactersAndCampaigns/MovesSection/useFilterMoves.ts
@@ -1,15 +1,13 @@
-import { useMemo, useState } from "react";
+import { Datasworn } from "@datasworn/core";
+import {
+  CATEGORY_VISIBILITY,
+  useDataswornCollectionFilter,
+} from "hooks/useDataswornCollectionFilter";
 import { useStore } from "stores/store";
 
-export enum CATEGORY_VISIBILITY {
-  HIDDEN,
-  SOME,
-  ALL,
-}
+export { CATEGORY_VISIBILITY };
 
 export function useFilterMoves() {
-  const [search, setSearch] = useState("");
-
   const moveCategories = useStore(
     (store) => store.rules.moveMaps.moveCategoryMap,
   );
@@ -20,83 +18,24 @@ export function useFilterMoves() {
   const moveMap = useStore((store) => store.rules.moveMaps.moveMap);
 
   const {
-    visibleMoveCategoryIds,
-    visibleMoveIds,
+    setSearch,
+    visibleCollectionIds,
+    visibleItemIds,
+    isSearchActive,
     isEmpty,
-    enhancesCollections,
-  } = useMemo(() => {
-    const visibleCategories: Record<string, CATEGORY_VISIBILITY> = {};
-    const visibleMoves: Record<string, boolean> = {};
-    let isEmpty: boolean = true;
-
-    const enhancesCollections: Record<string, string[]> = {};
-
-    Object.values(moveCategories).forEach((category) => {
-      if (category.enhances) {
-        category.enhances.forEach((enhancesId) => {
-          enhancesCollections[enhancesId] = [
-            ...(enhancesCollections[enhancesId] ?? []),
-            category._id,
-          ];
-        });
-      }
-
-      if (
-        !search ||
-        (category.name
-          .toLocaleLowerCase()
-          .includes(search.toLocaleLowerCase()) &&
-          Object.keys(category.contents ?? {}).length > 0)
-      ) {
-        visibleCategories[category._id] = CATEGORY_VISIBILITY.ALL;
-        isEmpty = false;
-        return;
-      }
-
-      let hasMove = false;
-
-      const contents = category.contents;
-      if (contents) {
-        Object.keys(contents).forEach((moveId) => {
-          const move = contents[moveId];
-
-          if (
-            move.name.toLocaleLowerCase().includes(search.toLocaleLowerCase())
-          ) {
-            hasMove = true;
-            visibleMoves[move._id] = true;
-          }
-        });
-      }
-      if (hasMove) {
-        isEmpty = false;
-        visibleCategories[category._id] = CATEGORY_VISIBILITY.SOME;
-        // TODO - double check this
-        // if (category.enhances) {
-        //   visibleCategories[category.enhances] = CATEGORY_VISIBILITY.SOME;
-        // }
-      } else {
-        visibleCategories[category._id] = CATEGORY_VISIBILITY.HIDDEN;
-      }
-    });
-
-    return {
-      visibleMoveCategoryIds: visibleCategories,
-      visibleMoveIds: visibleMoves,
-      isEmpty,
-      enhancesCollections,
-    };
-  }, [moveCategories, search]);
+  } = useDataswornCollectionFilter<Datasworn.MoveCategory, Datasworn.Move>({
+    collections: moveCategories,
+    rootCollectionIds: rootMoveCategories,
+  });
 
   return {
     moveCategories,
     moveMap,
     setSearch,
-    visibleMoveCategoryIds,
-    visibleMoveIds,
-    isSearchActive: !!search,
+    visibleMoveCategoryIds: visibleCollectionIds,
+    visibleMoveIds: visibleItemIds,
+    isSearchActive,
     isEmpty,
     rootMoveCategories,
-    enhancesCollections,
   };
 }

--- a/src/components/features/charactersAndCampaigns/OracleSection/OracleCollection.tsx
+++ b/src/components/features/charactersAndCampaigns/OracleSection/OracleCollection.tsx
@@ -10,6 +10,7 @@ import {
 } from "./useFilterOracles";
 import { useStore } from "stores/store";
 import { ToggleVisibilityButton } from "../../../shared/ToggleVisibilityButton";
+import { getOracleIdsForCollection } from "./oracleCollectionUtils";
 
 export interface OracleCollectionProps {
   collectionId: string;
@@ -18,7 +19,6 @@ export interface OracleCollectionProps {
   forceOpen?: boolean;
   visibleCollections: Record<string, CATEGORY_VISIBILITY>;
   visibleOracles: Record<string, boolean>;
-  enhancesCollections: Record<string, string[]>;
   disabled?: boolean;
   actionIsHide?: boolean;
 }
@@ -31,7 +31,6 @@ export function OracleCollection(props: OracleCollectionProps) {
     forceOpen,
     visibleCollections,
     visibleOracles,
-    enhancesCollections,
     disabled,
     actionIsHide,
   } = props;
@@ -60,39 +59,11 @@ export function OracleCollection(props: OracleCollectionProps) {
 
   const collection = collections[collectionId];
 
-  const contents = collection.contents;
-  const subCollections =
-    collection.oracle_type === "tables" && collection.collections;
-
-  const enhancingCollectionIds = enhancesCollections[collectionId];
-
   const { oracleIds, subCollectionIds } = useMemo(() => {
-    const oracleIds = Object.values(contents ?? {}).map((oracle) => oracle._id);
-
-    const subCollectionIds = Object.values(subCollections || {}).map(
-      (subCollection) => subCollection._id
-    );
-
-    (enhancingCollectionIds ?? []).forEach((enhancesId) => {
-      const enhancingCollection = collections[enhancesId];
-      if (enhancingCollection) {
-        oracleIds.push(
-          ...Object.values(enhancingCollection.contents ?? {}).map(
-            (oracle) => oracle._id
-          )
-        );
-        if (enhancingCollection.oracle_type === "tables") {
-          subCollectionIds.push(
-            ...Object.values(enhancingCollection.collections ?? {}).map(
-              (subCollection) => subCollection._id
-            )
-          );
-        }
-      }
-    });
-
-    return { oracleIds, subCollectionIds };
-  }, [contents, subCollections, collections, enhancingCollectionIds]);
+    return collection
+      ? getOracleIdsForCollection(collection)
+      : { oracleIds: [], subCollectionIds: [] };
+  }, [collection]);
 
   const hidden = hiddenOracles?.includes(collectionId);
 
@@ -160,7 +131,6 @@ export function OracleCollection(props: OracleCollectionProps) {
               forceOpen={forceOpen}
               visibleCollections={visibleCollections}
               visibleOracles={visibleOracles}
-              enhancesCollections={enhancesCollections}
               disabled={disabled || !isExpandedOrForced}
               actionIsHide={actionIsHide}
             />

--- a/src/components/features/charactersAndCampaigns/OracleSection/OracleSection.tsx
+++ b/src/components/features/charactersAndCampaigns/OracleSection/OracleSection.tsx
@@ -21,7 +21,6 @@ export function OracleSection(props: OraclesSectionProps) {
     isSearchActive,
     isEmpty,
     rootOracles,
-    enhancesCollections,
   } = useFilterOracles();
 
   return (
@@ -88,7 +87,6 @@ export function OracleSection(props: OraclesSectionProps) {
               forceOpen={isSearchActive}
               visibleCollections={visibleOracleCollectionIds}
               visibleOracles={visibleOracleIds}
-              enhancesCollections={enhancesCollections}
               actionIsHide={actionIsHide}
             />
           ))}

--- a/src/components/features/charactersAndCampaigns/OracleSection/oracleCollectionUtils.test.ts
+++ b/src/components/features/charactersAndCampaigns/OracleSection/oracleCollectionUtils.test.ts
@@ -1,0 +1,61 @@
+import { Datasworn } from "@datasworn/core";
+import { describe, expect, it } from "vitest";
+import { getOracleIdsForCollection } from "./oracleCollectionUtils";
+
+const action: Datasworn.OracleRollable = {
+  _id: "oracle_rollable:classic/action",
+  type: "oracle_rollable",
+  name: "Action",
+} as Datasworn.OracleRollable;
+
+const theme: Datasworn.OracleRollable = {
+  _id: "oracle_rollable:homebrew/theme",
+  type: "oracle_rollable",
+  name: "Theme",
+} as Datasworn.OracleRollable;
+
+describe("getOracleIdsForCollection", () => {
+  it("returns direct oracle and subcollection ids", () => {
+    const collection = {
+      _id: "oracle_collection:classic/characters",
+      type: "oracle_collection",
+      name: "Characters",
+      oracle_type: "tables",
+      contents: { action },
+      collections: {
+        names: {
+          _id: "oracle_collection:classic/characters/names",
+          type: "oracle_collection",
+          name: "Names",
+          oracle_type: "tables",
+          contents: {},
+          collections: {},
+        },
+      },
+    } as unknown as Datasworn.OracleTablesCollection;
+
+    expect(getOracleIdsForCollection(collection)).toEqual({
+      oracleIds: ["oracle_rollable:classic/action"],
+      subCollectionIds: ["oracle_collection:classic/characters/names"],
+    });
+  });
+
+  it("does not append enhancing collection contents after rules merging", () => {
+    const collection = {
+      _id: "oracle_collection:classic/core",
+      type: "oracle_collection",
+      name: "Core",
+      oracle_type: "tables",
+      contents: {
+        action,
+        theme,
+      },
+      collections: {},
+    } as unknown as Datasworn.OracleTablesCollection;
+
+    expect(getOracleIdsForCollection(collection).oracleIds).toEqual([
+      "oracle_rollable:classic/action",
+      "oracle_rollable:homebrew/theme",
+    ]);
+  });
+});

--- a/src/components/features/charactersAndCampaigns/OracleSection/oracleCollectionUtils.ts
+++ b/src/components/features/charactersAndCampaigns/OracleSection/oracleCollectionUtils.ts
@@ -1,0 +1,20 @@
+import type { CombinedCollectionType } from "./useFilterOracles";
+
+export function getOracleSubCollections(collection: CombinedCollectionType) {
+  if (collection.oracle_type !== "tables") {
+    return [];
+  }
+
+  return Object.values(collection.collections ?? {}) as CombinedCollectionType[];
+}
+
+export function getOracleIdsForCollection(collection: CombinedCollectionType) {
+  return {
+    oracleIds: Object.values(collection.contents ?? {}).map(
+      (oracle) => oracle._id,
+    ),
+    subCollectionIds: getOracleSubCollections(collection).map(
+      (subCollection) => subCollection._id,
+    ),
+  };
+}

--- a/src/components/features/charactersAndCampaigns/OracleSection/useFilterOracles.ts
+++ b/src/components/features/charactersAndCampaigns/OracleSection/useFilterOracles.ts
@@ -1,13 +1,14 @@
 import { Datasworn } from "@datasworn/core";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import {
+  CATEGORY_VISIBILITY,
+  useDataswornCollectionFilter,
+} from "hooks/useDataswornCollectionFilter";
 import { useStore } from "stores/store";
 import { License } from "types/Datasworn";
+import { getOracleSubCollections } from "./oracleCollectionUtils";
 
-export enum CATEGORY_VISIBILITY {
-  HIDDEN,
-  SOME,
-  ALL,
-}
+export { CATEGORY_VISIBILITY };
 
 type omittedKeys = "oracle_type" | "contents";
 export interface IPinnedOracleCollection
@@ -21,7 +22,6 @@ export type CombinedCollectionType =
   | IPinnedOracleCollection;
 
 export function useFilterOracles() {
-  const [search, setSearch] = useState("");
   const oracleCollectionsWithoutPinnedOracles = useStore(
     (store) => store.rules.oracleMaps.oracleCollectionMap
   );
@@ -84,105 +84,28 @@ export function useFilterOracles() {
   ]);
 
   const {
-    visibleOracleCollectionIds,
-    visibleOracleIds,
+    setSearch,
+    visibleCollectionIds,
+    visibleItemIds,
+    isSearchActive,
     isEmpty,
-    enhancesCollections,
-  } = useMemo(() => {
-    const visibleCollections: Record<string, CATEGORY_VISIBILITY> = {};
-    const visibleOracles: Record<string, boolean> = {};
-    let isEmpty: boolean = true;
-
-    const enhancesCollections: Record<string, string[]> = {};
-
-    const filterCollection = (collection: CombinedCollectionType): boolean => {
-      // TODO -double check this
-      // if (collection.enhances) {
-      //   enhancesCollections[collection.enhances] = [
-      //     ...(enhancesCollections[collection.enhances] ?? []),
-      //     collection._id,
-      //   ];
-      // }
-
-      const hasChildren =
-        (collection.oracle_type === "tables" &&
-          Object.keys(
-            (collection as unknown as Datasworn.OracleTablesCollection)
-              .collections ?? {}
-          ).length > 0) ||
-        Object.keys(collection.contents ?? {}).length > 0;
-
-      const searchIncludesCollectionName =
-        !search ||
-        collection.name
-          .toLocaleLowerCase()
-          .includes(search.toLocaleLowerCase());
-
-      if (hasChildren && searchIncludesCollectionName) {
-        isEmpty = false;
-        visibleCollections[collection._id] = CATEGORY_VISIBILITY.ALL;
-        return true;
-      }
-
-      let hasOracles = false;
-
-      if (collection.oracle_type === "tables" && collection.collections) {
-        Object.values(collection.collections).forEach((subCollection) => {
-          if (filterCollection(subCollection)) {
-            hasOracles = true;
-          }
-        });
-      }
-      if (collection.contents) {
-        Object.values(collection.contents).forEach(
-          (table: Datasworn.OracleRollable) => {
-            if (
-              table &&
-              table.name
-                .toLocaleLowerCase()
-                .includes(search.toLocaleLowerCase())
-            ) {
-              visibleOracles[table._id] = true;
-              hasOracles = true;
-            }
-          }
-        );
-      }
-
-      if (hasOracles) {
-        isEmpty = false;
-        visibleCollections[collection._id] = CATEGORY_VISIBILITY.SOME;
-        // TODO - check this
-        // if (collection.enhances) {
-        //   visibleCollections[collection.enhances] = CATEGORY_VISIBILITY.SOME;
-        // }
-      } else {
-        visibleCollections[collection._id] = CATEGORY_VISIBILITY.HIDDEN;
-      }
-
-      return hasOracles;
-    };
-    Object.values(oracleCollections).forEach((collection) => {
-      filterCollection(collection);
-    });
-
-    return {
-      visibleOracleCollectionIds: visibleCollections,
-      visibleOracleIds: visibleOracles,
-      isEmpty,
-      enhancesCollections,
-    };
-  }, [oracleCollections, search]);
+  } = useDataswornCollectionFilter<
+    CombinedCollectionType,
+    Datasworn.OracleRollable
+  >({
+    collections: oracleCollections,
+    rootCollectionIds: rootOracles,
+    getSubCollections: getOracleSubCollections,
+  });
 
   return {
     oracleCollections,
     oracles,
     setSearch,
-    visibleOracleCollectionIds,
-    visibleOracleIds,
-    isSearchActive: !!search,
+    visibleOracleCollectionIds: visibleCollectionIds,
+    visibleOracleIds: visibleItemIds,
+    isSearchActive,
     isEmpty,
     rootOracles,
-    enhancesCollections,
   };
 }

--- a/src/hooks/__tests__/useDataswornCollectionFilter.test.ts
+++ b/src/hooks/__tests__/useDataswornCollectionFilter.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import {
+  CATEGORY_VISIBILITY,
+  filterDataswornCollections,
+} from "../useDataswornCollectionFilter";
+
+interface TestItem {
+  _id: string;
+  name: string;
+}
+
+interface TestCollection {
+  _id: string;
+  name: string;
+  contents?: Record<string, TestItem>;
+  collections?: Record<string, TestCollection>;
+  enhances?: string[];
+}
+
+const strike: TestItem = {
+  _id: "move:classic/combat/strike",
+  name: "Strike",
+};
+
+const customMove: TestItem = {
+  _id: "move:homebrew/combat/custom",
+  name: "Custom Move",
+};
+
+function filter(
+  collections: Record<string, TestCollection>,
+  search: string,
+) {
+  return filterDataswornCollections({
+    collections,
+    rootCollectionIds: Object.keys(collections),
+    search,
+    getSubCollections: (collection) =>
+      Object.values(collection.collections ?? {}),
+  });
+}
+
+describe("filterDataswornCollections", () => {
+  it("marks populated collections visible when search is empty", () => {
+    const result = filter(
+      {
+        combat: {
+          _id: "move_category:classic/combat",
+          name: "Combat",
+          contents: { strike },
+        },
+      },
+      "",
+    );
+
+    expect(result.isEmpty).toBe(false);
+    expect(result.visibleCollectionIds["move_category:classic/combat"]).toBe(
+      CATEGORY_VISIBILITY.ALL,
+    );
+  });
+
+  it("marks a collection ALL when the collection name matches", () => {
+    const result = filter(
+      {
+        combat: {
+          _id: "move_category:classic/combat",
+          name: "Combat",
+          contents: { strike },
+        },
+      },
+      "combat",
+    );
+
+    expect(result.visibleCollectionIds["move_category:classic/combat"]).toBe(
+      CATEGORY_VISIBILITY.ALL,
+    );
+    expect(result.visibleItemIds).toEqual({});
+  });
+
+  it("marks a collection SOME and the item visible when only an item matches", () => {
+    const result = filter(
+      {
+        combat: {
+          _id: "move_category:classic/combat",
+          name: "Combat",
+          contents: { strike },
+        },
+      },
+      "strike",
+    );
+
+    expect(result.visibleCollectionIds["move_category:classic/combat"]).toBe(
+      CATEGORY_VISIBILITY.SOME,
+    );
+    expect(result.visibleItemIds["move:classic/combat/strike"]).toBe(true);
+  });
+
+  it("bubbles nested collection matches up to the parent collection", () => {
+    const result = filter(
+      {
+        characters: {
+          _id: "oracle_collection:classic/characters",
+          name: "Characters",
+          collections: {
+            names: {
+              _id: "oracle_collection:classic/characters/names",
+              name: "Names",
+              contents: {
+                given: {
+                  _id: "oracle_rollable:classic/characters/names/given",
+                  name: "Given Name",
+                },
+              },
+            },
+          },
+        },
+      },
+      "given",
+    );
+
+    expect(
+      result.visibleCollectionIds["oracle_collection:classic/characters"],
+    ).toBe(CATEGORY_VISIBILITY.SOME);
+    expect(
+      result.visibleCollectionIds["oracle_collection:classic/characters/names"],
+    ).toBe(CATEGORY_VISIBILITY.SOME);
+    expect(
+      result.visibleItemIds["oracle_rollable:classic/characters/names/given"],
+    ).toBe(true);
+  });
+
+  it("does not append enhancing collection contents during filtering", () => {
+    const result = filter(
+      {
+        combat: {
+          _id: "move_category:classic/combat",
+          name: "Combat",
+          contents: {
+            strike,
+            custom: customMove,
+          },
+        },
+        homebrewCombat: {
+          _id: "move_category:homebrew/combat",
+          name: "Homebrew Combat",
+          enhances: ["move_category:classic/combat"],
+          contents: {
+            custom: customMove,
+          },
+        },
+      },
+      "custom",
+    );
+
+    expect(result.visibleItemIds).toEqual({
+      "move:homebrew/combat/custom": true,
+    });
+  });
+
+  it("reports empty when no collections or items match", () => {
+    const result = filter(
+      {
+        combat: {
+          _id: "move_category:classic/combat",
+          name: "Combat",
+          contents: { strike },
+        },
+      },
+      "supply",
+    );
+
+    expect(result.isEmpty).toBe(true);
+    expect(result.visibleCollectionIds["move_category:classic/combat"]).toBe(
+      CATEGORY_VISIBILITY.HIDDEN,
+    );
+  });
+});

--- a/src/hooks/useDataswornCollectionFilter.ts
+++ b/src/hooks/useDataswornCollectionFilter.ts
@@ -1,0 +1,142 @@
+import { useMemo, useState } from "react";
+
+export enum CATEGORY_VISIBILITY {
+  HIDDEN,
+  SOME,
+  ALL,
+}
+
+export interface DataswornCollectionFilterItem {
+  _id: string;
+  name: string;
+}
+
+export interface DataswornCollectionFilterCollection<
+  TItem extends DataswornCollectionFilterItem,
+> {
+  _id: string;
+  name: string;
+  contents?: Record<string, TItem>;
+}
+
+export interface DataswornCollectionFilterOptions<
+  TCollection extends DataswornCollectionFilterCollection<TItem>,
+  TItem extends DataswornCollectionFilterItem,
+> {
+  collections: Record<string, TCollection>;
+  rootCollectionIds: string[];
+  search: string;
+  getItems?: (collection: TCollection) => TItem[];
+  getSubCollections?: (collection: TCollection) => TCollection[];
+}
+
+export interface DataswornCollectionFilterResult {
+  visibleCollectionIds: Record<string, CATEGORY_VISIBILITY>;
+  visibleItemIds: Record<string, boolean>;
+  isEmpty: boolean;
+}
+
+export function filterDataswornCollections<
+  TCollection extends DataswornCollectionFilterCollection<TItem>,
+  TItem extends DataswornCollectionFilterItem,
+>(
+  options: DataswornCollectionFilterOptions<TCollection, TItem>,
+): DataswornCollectionFilterResult {
+  const { collections, search, getItems, getSubCollections } = options;
+  const normalizedSearch = search.toLocaleLowerCase();
+
+  const visibleCollectionIds: Record<string, CATEGORY_VISIBILITY> = {};
+  const visibleItemIds: Record<string, boolean> = {};
+  let isEmpty = true;
+
+  const filterCollection = (collection: TCollection): boolean => {
+    const items = getItems
+      ? getItems(collection)
+      : Object.values(collection.contents ?? {});
+    const subCollections = getSubCollections
+      ? getSubCollections(collection)
+      : [];
+    const hasChildren = items.length > 0 || subCollections.length > 0;
+    const collectionMatches =
+      !normalizedSearch ||
+      collection.name.toLocaleLowerCase().includes(normalizedSearch);
+
+    if (hasChildren && collectionMatches) {
+      isEmpty = false;
+      visibleCollectionIds[collection._id] = CATEGORY_VISIBILITY.ALL;
+      return true;
+    }
+
+    let hasMatchingDescendant = false;
+
+    subCollections.forEach((subCollection) => {
+      if (filterCollection(subCollection)) {
+        hasMatchingDescendant = true;
+      }
+    });
+
+    items.forEach((item) => {
+      if (item.name.toLocaleLowerCase().includes(normalizedSearch)) {
+        visibleItemIds[item._id] = true;
+        hasMatchingDescendant = true;
+      }
+    });
+
+    if (hasMatchingDescendant) {
+      isEmpty = false;
+      visibleCollectionIds[collection._id] = CATEGORY_VISIBILITY.SOME;
+    } else {
+      visibleCollectionIds[collection._id] = CATEGORY_VISIBILITY.HIDDEN;
+    }
+
+    return hasMatchingDescendant;
+  };
+
+  Object.values(collections).forEach((collection) => {
+    filterCollection(collection);
+  });
+
+  return {
+    visibleCollectionIds,
+    visibleItemIds,
+    isEmpty,
+  };
+}
+
+export function useDataswornCollectionFilter<
+  TCollection extends DataswornCollectionFilterCollection<TItem>,
+  TItem extends DataswornCollectionFilterItem,
+>(
+  {
+    collections,
+    rootCollectionIds,
+    getItems,
+    getSubCollections,
+  }: Omit<
+    DataswornCollectionFilterOptions<TCollection, TItem>,
+    "search"
+  >,
+) {
+  const [search, setSearch] = useState("");
+
+  const { visibleCollectionIds, visibleItemIds, isEmpty } = useMemo(
+    () =>
+      filterDataswornCollections({
+        collections,
+        rootCollectionIds,
+        getItems,
+        getSubCollections,
+        search,
+      }),
+    [collections, rootCollectionIds, getItems, getSubCollections, search],
+  );
+
+  return {
+    setSearch,
+    visibleCollectionIds,
+    visibleItemIds,
+    isSearchActive: !!search,
+    isEmpty,
+    rootCollectionIds,
+  };
+}


### PR DESCRIPTION
## Summary

- Add a shared `useDataswornCollectionFilter` hook and pure `filterDataswornCollections` helper for Datasworn collection search/visibility.
- Migrate moves and oracles to the shared filtering logic while preserving their existing UI-specific return shapes.
- Remove render-time enhancement appending for moves/oracles so enhanced content that is already merged in the rules layer is not displayed twice.
- Add focused regression coverage for the user-reported duplicated enhanced moves case, plus nested oracle-style collection filtering.

## Why

Moves, oracles, and assets all share similar Datasworn collection traversal/filtering behavior. Moves and oracles were carrying duplicate local search logic, and the old render-time enhancement append path could duplicate homebrew content once enhanced collections had already been merged into their target category.

## Validation

- `npx vitest run src/hooks/__tests__/useDataswornCollectionFilter.test.ts src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.test.ts src/components/features/charactersAndCampaigns/OracleSection/oracleCollectionUtils.test.ts`
- `npx tsc --noEmit`
- `npx eslint . --quiet`