### PR TITLE
feat(lodestar): update oracle data

### DIFF
--- a/src/data/lodestar.json
+++ b/src/data/lodestar.json
@@ -1,5235 +1,17314 @@
 {
-  "_id": "lodestar",
-  "datasworn_version": "0.1.0",
-  "type": "expansion",
-  "ruleset": "classic",
-  "title": "Ironsworn Lodestar",
-  "authors": [
-    {
-      "name": "Shawn Tomkin"
-    }
-  ],
-  "date": "2025-05-01",
-  "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-  "url": "https://ironswornrpg.com",
-  "oracles": {
-    "combat": {
-      "_id": "oracle_collection:lodestar/combat",
-      "type": "oracle_collection",
-      "name": "Combat Oracles",
-      "oracle_type": "tables",
-      "contents": {
-        "battleground": {
-          "_id": "oracle_rollable:lodestar/combat/battleground",
-          "type": "oracle_rollable",
-          "name": "Battleground",
-          "oracle_type": "table_text2",
-          "dice": "1d100",
-          "summary": "Roll on this oracle to reveal a feature of the combat environment that affects the fight. Use the result to inspire tactical choices or complicate the situation.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result",
-            "text2": "Details"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.0",
-              "roll": {
-                "min": 1,
-                "max": 5
-              },
-              "text": "Slippery surface",
-              "text2": "Mud, ice, rain-slick rocks"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.1",
-              "roll": {
-                "min": 6,
-                "max": 10
-              },
-              "text": "Encumbering terrain",
-              "text2": "Water, muck, deep snow, webs"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.2",
-              "roll": {
-                "min": 11,
-                "max": 15
-              },
-              "text": "Precipitous drop",
-              "text2": "Cliff, ravine, pit, stairs"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.3",
-              "roll": {
-                "min": 16,
-                "max": 20
-              },
-              "text": "Obstructed path",
-              "text2": "Barricade, toppled ruin, fallen tree"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.4",
-              "roll": {
-                "min": 21,
-                "max": 25
-              },
-              "text": "High ground",
-              "text2": "Mound, outcropping, climbable structure"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.5",
-              "roll": {
-                "min": 26,
-                "max": 30
-              },
-              "text": "Cluttered terrain",
-              "text2": "Rubble, rocks, roots"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.6",
-              "roll": {
-                "min": 31,
-                "max": 35
-              },
-              "text": "Low visibility",
-              "text2": "Darkness, smoke, mist, torrential rain"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.7",
-              "roll": {
-                "min": 36,
-                "max": 40
-              },
-              "text": "Impassable border",
-              "text2": "Deep waterway, high wall, cliff face, locked door"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.8",
-              "roll": {
-                "min": 41,
-                "max": 45
-              },
-              "text": "Scattered cover",
-              "text2": "Low walls, boulders, trees, crates"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.9",
-              "roll": {
-                "min": 46,
-                "max": 50
-              },
-              "text": "Cramped spaces",
-              "text2": "Narrow tunnel, crowded room, dense woods"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.10",
-              "roll": {
-                "min": 51,
-                "max": 55
-              },
-              "text": "Treacherous ground",
-              "text2": "Fire pit, boiling hot spring, quagmire"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.11",
-              "roll": {
-                "min": 56,
-                "max": 60
-              },
-              "text": "Restricted approach",
-              "text2": "Bridge, corridor, river ford, narrow canyon"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.12",
-              "roll": {
-                "min": 61,
-                "max": 65
-              },
-              "text": "Collapsing foundation",
-              "text2": "Crumbling ruins, thin ice, undermined earth"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.13",
-              "roll": {
-                "min": 66,
-                "max": 70
-              },
-              "text": "Bounded space",
-              "text2": "Dueling circle, woodland clearing, standing stones"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.14",
-              "roll": {
-                "min": 71,
-                "max": 75
-              },
-              "text": "Pitched ground",
-              "text2": "Steep hillside, rooftop, collapsed ruin, ship deck"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.15",
-              "roll": {
-                "min": 76,
-                "max": 80
-              },
-              "text": "Hidden hazard",
-              "text2": "Trap, sinkhole, lurking creature, waiting ambushers"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.16",
-              "roll": {
-                "min": 81,
-                "max": 85
-              },
-              "text": "Frenzied distractions",
-              "text2": "Noncombatants, panicked creatures, insect swarms"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.17",
-              "roll": {
-                "min": 86,
-                "max": 90
-              },
-              "text": "Destructive chaos",
-              "text2": "Storm, fire, flooding, rampaging creature"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.18",
-              "roll": {
-                "min": 91,
-                "max": 95
-              },
-              "text": "Unnatural forces",
-              "text2": "Mystic energies, runic symbols, sorcerous artifacts"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/battleground.19",
-              "roll": {
-                "min": 96,
-                "max": 100
-              },
-              "text": "Cursed ground",
-              "text2": "Corpses, shambling undead, ghostly specters"
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 94,
-            "url": "https://ironswornrpg.com"
-          }
-        },
-        "tactic": {
-          "_id": "oracle_rollable:lodestar/combat/tactic",
-          "type": "oracle_rollable",
-          "name": "Tactic",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Use this oracle to help inspire an action for an NPC in combat. When you're not sure what your foe does next, particularly when they have initiative, roll on this table and interpret the result as appropriate to the situation.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.0",
-              "roll": {
-                "min": 1,
-                "max": 3
-              },
-              "text": "Compel a surrender."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.1",
-              "roll": {
-                "min": 4,
-                "max": 6
-              },
-              "text": "Coordinate with allies."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.2",
-              "roll": {
-                "min": 7,
-                "max": 9
-              },
-              "text": "Gather reinforcements."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.3",
-              "roll": {
-                "min": 10,
-                "max": 13
-              },
-              "text": "Seize something or someone."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.4",
-              "roll": {
-                "min": 14,
-                "max": 17
-              },
-              "text": "Provoke a reckless response."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.5",
-              "roll": {
-                "min": 18,
-                "max": 21
-              },
-              "text": "Intimidate or frighten."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.6",
-              "roll": {
-                "min": 22,
-                "max": 25
-              },
-              "text": "Reveal a surprising truth."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.7",
-              "roll": {
-                "min": 26,
-                "max": 29
-              },
-              "text": "Shift focus to something else."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.8",
-              "roll": {
-                "min": 30,
-                "max": 33
-              },
-              "text": "Destroy or damage something."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.9",
-              "roll": {
-                "min": 34,
-                "max": 39
-              },
-              "text": "Take a decisive action."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.10",
-              "roll": {
-                "min": 40,
-                "max": 45
-              },
-              "text": "Reinforce defenses."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.11",
-              "roll": {
-                "min": 46,
-                "max": 52
-              },
-              "text": "Ready an action."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.12",
-              "roll": {
-                "min": 53,
-                "max": 60
-              },
-              "text": "Use the terrain to gain advantage."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.13",
-              "roll": {
-                "min": 61,
-                "max": 68
-              },
-              "text": "Take advantage of an opening."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.14",
-              "roll": {
-                "min": 69,
-                "max": 78
-              },
-              "text": "Create an opportunity."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.15",
-              "roll": {
-                "min": 79,
-                "max": 89
-              },
-              "text": "Attack with precision."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.16",
-              "roll": {
-                "min": 90,
-                "max": 99
-              },
-              "text": "Attack with power."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/combat/tactic.17",
-              "roll": {
-                "min": 100,
-                "max": 100
-              },
-              "text": "Take an unexpected action."
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 95,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn: Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 94,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "core": {
-      "_id": "oracle_collection:lodestar/core",
-      "type": "oracle_collection",
-      "name": "Core Oracles",
-      "oracle_type": "tables",
-      "contents": {
-        "descriptor": {
-          "_id": "oracle_rollable:lodestar/core/descriptor",
-          "type": "oracle_rollable",
-          "name": "Descriptor",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Use the Descriptor oracle to add texture to the details of a location or event. Combined with a Focus oracle result, it provides a more specific prompt than either oracle alone.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.0",
-              "roll": {
-                "min": 1,
-                "max": 1
-              },
-              "text": "Small",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.1",
-              "roll": {
-                "min": 2,
-                "max": 2
-              },
-              "text": "Collapsed",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.2",
-              "roll": {
-                "min": 3,
-                "max": 3
-              },
-              "text": "Protected",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.3",
-              "roll": {
-                "min": 4,
-                "max": 4
-              },
-              "text": "Infested",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.4",
-              "roll": {
-                "min": 5,
-                "max": 5
-              },
-              "text": "Misty",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.5",
-              "roll": {
-                "min": 6,
-                "max": 6
-              },
-              "text": "Towering",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.6",
-              "roll": {
-                "min": 7,
-                "max": 7
-              },
-              "text": "Light",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.7",
-              "roll": {
-                "min": 8,
-                "max": 8
-              },
-              "text": "Marked",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.8",
-              "roll": {
-                "min": 9,
-                "max": 9
-              },
-              "text": "Crafted",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.9",
-              "roll": {
-                "min": 10,
-                "max": 10
-              },
-              "text": "Remote",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.10",
-              "roll": {
-                "min": 11,
-                "max": 11
-              },
-              "text": "Deep",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.11",
-              "roll": {
-                "min": 12,
-                "max": 12
-              },
-              "text": "Captured",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.12",
-              "roll": {
-                "min": 13,
-                "max": 13
-              },
-              "text": "Ruined",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.13",
-              "roll": {
-                "min": 14,
-                "max": 14
-              },
-              "text": "Safe",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.14",
-              "roll": {
-                "min": 15,
-                "max": 15
-              },
-              "text": "Precious",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.15",
-              "roll": {
-                "min": 16,
-                "max": 16
-              },
-              "text": "Abandoned",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.16",
-              "roll": {
-                "min": 17,
-                "max": 17
-              },
-              "text": "Inaccessible",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.17",
-              "roll": {
-                "min": 18,
-                "max": 18
-              },
-              "text": "Barren",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.18",
-              "roll": {
-                "min": 19,
-                "max": 19
-              },
-              "text": "Guarded",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.19",
-              "roll": {
-                "min": 20,
-                "max": 20
-              },
-              "text": "Impassable",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.20",
-              "roll": {
-                "min": 21,
-                "max": 21
-              },
-              "text": "Corrupted",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.21",
-              "roll": {
-                "min": 22,
-                "max": 22
-              },
-              "text": "Foreboding",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.22",
-              "roll": {
-                "min": 23,
-                "max": 23
-              },
-              "text": "Wild",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.23",
-              "roll": {
-                "min": 24,
-                "max": 24
-              },
-              "text": "Fragile",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.24",
-              "roll": {
-                "min": 25,
-                "max": 25
-              },
-              "text": "Isolated",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.25",
-              "roll": {
-                "min": 26,
-                "max": 26
-              },
-              "text": "Inhabited",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.26",
-              "roll": {
-                "min": 27,
-                "max": 27
-              },
-              "text": "Defended",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.27",
-              "roll": {
-                "min": 28,
-                "max": 28
-              },
-              "text": "Active",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.28",
-              "roll": {
-                "min": 29,
-                "max": 29
-              },
-              "text": "Bloody",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.29",
-              "roll": {
-                "min": 30,
-                "max": 30
-              },
-              "text": "Dying",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.30",
-              "roll": {
-                "min": 31,
-                "max": 31
-              },
-              "text": "Grim",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.31",
-              "roll": {
-                "min": 32,
-                "max": 32
-              },
-              "text": "Shrouded",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.32",
-              "roll": {
-                "min": 33,
-                "max": 33
-              },
-              "text": "Dead",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.33",
-              "roll": {
-                "min": 34,
-                "max": 34
-              },
-              "text": "Sealed",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.34",
-              "roll": {
-                "min": 35,
-                "max": 35
-              },
-              "text": "Flooded",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.35",
-              "roll": {
-                "min": 36,
-                "max": 36
-              },
-              "text": "Withered",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.36",
-              "roll": {
-                "min": 37,
-                "max": 37
-              },
-              "text": "Lush",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.37",
-              "roll": {
-                "min": 38,
-                "max": 38
-              },
-              "text": "Fortified",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.38",
-              "roll": {
-                "min": 39,
-                "max": 39
-              },
-              "text": "Beautiful",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.39",
-              "roll": {
-                "min": 40,
-                "max": 40
-              },
-              "text": "Blocked",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.40",
-              "roll": {
-                "min": 41,
-                "max": 41
-              },
-              "text": "Desolate",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.41",
-              "roll": {
-                "min": 42,
-                "max": 42
-              },
-              "text": "Deadly",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.42",
-              "roll": {
-                "min": 43,
-                "max": 43
-              },
-              "text": "Massive",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.43",
-              "roll": {
-                "min": 44,
-                "max": 44
-              },
-              "text": "Hallowed",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.44",
-              "roll": {
-                "min": 45,
-                "max": 45
-              },
-              "text": "Confined",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.45",
-              "roll": {
-                "min": 46,
-                "max": 46
-              },
-              "text": "Unusual",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.46",
-              "roll": {
-                "min": 47,
-                "max": 47
-              },
-              "text": "Mysterious",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.47",
-              "roll": {
-                "min": 48,
-                "max": 48
-              },
-              "text": "Strange",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.48",
-              "roll": {
-                "min": 49,
-                "max": 49
-              },
-              "text": "Depleted",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.49",
-              "roll": {
-                "min": 50,
-                "max": 50
-              },
-              "text": "Crowded",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.50",
-              "roll": {
-                "min": 51,
-                "max": 51
-              },
-              "text": "Fertile",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.51",
-              "roll": {
-                "min": 52,
-                "max": 52
-              },
-              "text": "Diverse",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.52",
-              "roll": {
-                "min": 53,
-                "max": 53
-              },
-              "text": "Sheltered",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.53",
-              "roll": {
-                "min": 54,
-                "max": 54
-              },
-              "text": "Destroyed",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.54",
-              "roll": {
-                "min": 55,
-                "max": 55
-              },
-              "text": "Open",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.55",
-              "roll": {
-                "min": 56,
-                "max": 56
-              },
-              "text": "Exposed",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.56",
-              "roll": {
-                "min": 57,
-                "max": 57
-              },
-              "text": "Contested",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.57",
-              "roll": {
-                "min": 58,
-                "max": 58
-              },
-              "text": "Blighted",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.58",
-              "roll": {
-                "min": 59,
-                "max": 59
-              },
-              "text": "Rugged",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.59",
-              "roll": {
-                "min": 60,
-                "max": 60
-              },
-              "text": "Unnatural",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.60",
-              "roll": {
-                "min": 61,
-                "max": 61
-              },
-              "text": "Secret",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.61",
-              "roll": {
-                "min": 62,
-                "max": 62
-              },
-              "text": "Dark",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.62",
-              "roll": {
-                "min": 63,
-                "max": 63
-              },
-              "text": "Sunken",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.63",
-              "roll": {
-                "min": 64,
-                "max": 64
-              },
-              "text": "Abundant",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.64",
-              "roll": {
-                "min": 65,
-                "max": 65
-              },
-              "text": "Raided",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.65",
-              "roll": {
-                "min": 66,
-                "max": 66
-              },
-              "text": "Suspended",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.66",
-              "roll": {
-                "min": 67,
-                "max": 67
-              },
-              "text": "Hostile",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.67",
-              "roll": {
-                "min": 68,
-                "max": 68
-              },
-              "text": "Empty",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.68",
-              "roll": {
-                "min": 69,
-                "max": 69
-              },
-              "text": "Overgrown",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.69",
-              "roll": {
-                "min": 70,
-                "max": 70
-              },
-              "text": "Chaotic",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.70",
-              "roll": {
-                "min": 71,
-                "max": 71
-              },
-              "text": "Peaceful",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.71",
-              "roll": {
-                "min": 72,
-                "max": 72
-              },
-              "text": "Broken",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.72",
-              "roll": {
-                "min": 73,
-                "max": 73
-              },
-              "text": "Ensnaring",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.73",
-              "roll": {
-                "min": 74,
-                "max": 74
-              },
-              "text": "Frozen",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.74",
-              "roll": {
-                "min": 75,
-                "max": 75
-              },
-              "text": "Ravaged",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.75",
-              "roll": {
-                "min": 76,
-                "max": 76
-              },
-              "text": "Expansive",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.76",
-              "roll": {
-                "min": 77,
-                "max": 77
-              },
-              "text": "Toxic",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.77",
-              "roll": {
-                "min": 78,
-                "max": 78
-              },
-              "text": "High",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.78",
-              "roll": {
-                "min": 79,
-                "max": 79
-              },
-              "text": "Sacred",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.79",
-              "roll": {
-                "min": 80,
-                "max": 80
-              },
-              "text": "Low",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.80",
-              "roll": {
-                "min": 81,
-                "max": 81
-              },
-              "text": "Forsaken",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.81",
-              "roll": {
-                "min": 82,
-                "max": 82
-              },
-              "text": "Fallen",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.82",
-              "roll": {
-                "min": 83,
-                "max": 83
-              },
-              "text": "Shadowy",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.83",
-              "roll": {
-                "min": 84,
-                "max": 84
-              },
-              "text": "Unstable",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.84",
-              "roll": {
-                "min": 85,
-                "max": 85
-              },
-              "text": "Hidden",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.85",
-              "roll": {
-                "min": 86,
-                "max": 86
-              },
-              "text": "Haunted",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.86",
-              "roll": {
-                "min": 87,
-                "max": 87
-              },
-              "text": "Buried",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.87",
-              "roll": {
-                "min": 88,
-                "max": 88
-              },
-              "text": "Damaged",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.88",
-              "roll": {
-                "min": 89,
-                "max": 89
-              },
-              "text": "Ancient",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.89",
-              "roll": {
-                "min": 90,
-                "max": 90
-              },
-              "text": "Scarred",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.90",
-              "roll": {
-                "min": 91,
-                "max": 91
-              },
-              "text": "Elevated",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.91",
-              "roll": {
-                "min": 92,
-                "max": 92
-              },
-              "text": "Forgotten",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.92",
-              "roll": {
-                "min": 93,
-                "max": 93
-              },
-              "text": "Preserved",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.93",
-              "roll": {
-                "min": 94,
-                "max": 94
-              },
-              "text": "Trapped",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.94",
-              "roll": {
-                "min": 95,
-                "max": 95
-              },
-              "text": "Mystic",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.95",
-              "roll": {
-                "min": 96,
-                "max": 96
-              },
-              "text": "Natural",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.96",
-              "roll": {
-                "min": 97,
-                "max": 97
-              },
-              "text": "Treacherous",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.97",
-              "roll": {
-                "min": 98,
-                "max": 98
-              },
-              "text": "Watery",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.98",
-              "roll": {
-                "min": 99,
-                "max": 99
-              },
-              "text": "Moving",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/descriptor.99",
-              "roll": {
-                "min": 100,
-                "max": 100
-              },
-              "text": "Foul",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "adjective"
-                }
-              }
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 52,
-            "url": "https://ironswornrpg.com"
-          }
-        },
-        "focus": {
-          "_id": "oracle_rollable:lodestar/core/focus",
-          "type": "oracle_rollable",
-          "name": "Focus",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Use the Focus oracle to add detail or subject matter to a location or event. Combined with a Descriptor oracle result, it provides a more specific prompt than either oracle alone.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.0",
-              "roll": {
-                "min": 1,
-                "max": 1
-              },
-              "text": "Bridge",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.1",
-              "roll": {
-                "min": 2,
-                "max": 2
-              },
-              "text": "Being",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.2",
-              "roll": {
-                "min": 3,
-                "max": 3
-              },
-              "text": "Archive",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.3",
-              "roll": {
-                "min": 4,
-                "max": 4
-              },
-              "text": "Gap",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.4",
-              "roll": {
-                "min": 5,
-                "max": 5
-              },
-              "text": "Message",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.5",
-              "roll": {
-                "min": 6,
-                "max": 6
-              },
-              "text": "Denizen",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.6",
-              "roll": {
-                "min": 7,
-                "max": 7
-              },
-              "text": "Commodity",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.7",
-              "roll": {
-                "min": 8,
-                "max": 8
-              },
-              "text": "Vegetation",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.8",
-              "roll": {
-                "min": 9,
-                "max": 9
-              },
-              "text": "Rubble",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.9",
-              "roll": {
-                "min": 10,
-                "max": 10
-              },
-              "text": "Rendezvous",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.10",
-              "roll": {
-                "min": 11,
-                "max": 11
-              },
-              "text": "Hideaway",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.11",
-              "roll": {
-                "min": 12,
-                "max": 12
-              },
-              "text": "Vault",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.12",
-              "roll": {
-                "min": 13,
-                "max": 13
-              },
-              "text": "Crossing",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.13",
-              "roll": {
-                "min": 14,
-                "max": 14
-              },
-              "text": "Camp",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.14",
-              "roll": {
-                "min": 15,
-                "max": 15
-              },
-              "text": "Inhabitant",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.15",
-              "roll": {
-                "min": 16,
-                "max": 16
-              },
-              "text": "Landscape",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.16",
-              "roll": {
-                "min": 17,
-                "max": 17
-              },
-              "text": "Boundary",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.17",
-              "roll": {
-                "min": 18,
-                "max": 18
-              },
-              "text": "Entry",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.18",
-              "roll": {
-                "min": 19,
-                "max": 19
-              },
-              "text": "Grave",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.19",
-              "roll": {
-                "min": 20,
-                "max": 20
-              },
-              "text": "Beast",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.20",
-              "roll": {
-                "min": 21,
-                "max": 21
-              },
-              "text": "Construction",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.21",
-              "roll": {
-                "min": 22,
-                "max": 22
-              },
-              "text": "Iron",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.22",
-              "roll": {
-                "min": 23,
-                "max": 23
-              },
-              "text": "Threshold",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.23",
-              "roll": {
-                "min": 24,
-                "max": 24
-              },
-              "text": "Sound",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.24",
-              "roll": {
-                "min": 25,
-                "max": 25
-              },
-              "text": "Debris",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.25",
-              "roll": {
-                "min": 26,
-                "max": 26
-              },
-              "text": "Monument",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.26",
-              "roll": {
-                "min": 27,
-                "max": 27
-              },
-              "text": "Terrain",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.27",
-              "roll": {
-                "min": 28,
-                "max": 28
-              },
-              "text": "Battlefield",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.28",
-              "roll": {
-                "min": 29,
-                "max": 29
-              },
-              "text": "Stone",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.29",
-              "roll": {
-                "min": 30,
-                "max": 30
-              },
-              "text": "Shortcut",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.30",
-              "roll": {
-                "min": 31,
-                "max": 31
-              },
-              "text": "Symbol",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.31",
-              "roll": {
-                "min": 32,
-                "max": 32
-              },
-              "text": "Ambush",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.32",
-              "roll": {
-                "min": 33,
-                "max": 33
-              },
-              "text": "Water",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.33",
-              "roll": {
-                "min": 34,
-                "max": 34
-              },
-              "text": "Viewpoint",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.34",
-              "roll": {
-                "min": 35,
-                "max": 35
-              },
-              "text": "Environment",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.35",
-              "roll": {
-                "min": 36,
-                "max": 36
-              },
-              "text": "Excavation",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.36",
-              "roll": {
-                "min": 37,
-                "max": 37
-              },
-              "text": "Person",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.37",
-              "roll": {
-                "min": 38,
-                "max": 38
-              },
-              "text": "Gathering",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.38",
-              "roll": {
-                "min": 39,
-                "max": 39
-              },
-              "text": "Enclosure",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.39",
-              "roll": {
-                "min": 40,
-                "max": 40
-              },
-              "text": "Ritual",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.40",
-              "roll": {
-                "min": 41,
-                "max": 41
-              },
-              "text": "Weather",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.41",
-              "roll": {
-                "min": 42,
-                "max": 42
-              },
-              "text": "Precipice",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.42",
-              "roll": {
-                "min": 43,
-                "max": 43
-              },
-              "text": "Opening",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.43",
-              "roll": {
-                "min": 44,
-                "max": 44
-              },
-              "text": "Rift",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.44",
-              "roll": {
-                "min": 45,
-                "max": 45
-              },
-              "text": "Bones",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.45",
-              "roll": {
-                "min": 46,
-                "max": 46
-              },
-              "text": "Transport",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.46",
-              "roll": {
-                "min": 47,
-                "max": 47
-              },
-              "text": "Territory",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.47",
-              "roll": {
-                "min": 48,
-                "max": 48
-              },
-              "text": "Clearing",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.48",
-              "roll": {
-                "min": 49,
-                "max": 49
-              },
-              "text": "Hole",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.49",
-              "roll": {
-                "min": 50,
-                "max": 50
-              },
-              "text": "Growth",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.50",
-              "roll": {
-                "min": 51,
-                "max": 51
-              },
-              "text": "Portal",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.51",
-              "roll": {
-                "min": 52,
-                "max": 52
-              },
-              "text": "Route",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.52",
-              "roll": {
-                "min": 53,
-                "max": 53
-              },
-              "text": "Hazard",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.53",
-              "roll": {
-                "min": 54,
-                "max": 54
-              },
-              "text": "Habitat",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.54",
-              "roll": {
-                "min": 55,
-                "max": 55
-              },
-              "text": "Trail",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.55",
-              "roll": {
-                "min": 56,
-                "max": 56
-              },
-              "text": "Illusion",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.56",
-              "roll": {
-                "min": 57,
-                "max": 57
-              },
-              "text": "Refuge",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.57",
-              "roll": {
-                "min": 58,
-                "max": 58
-              },
-              "text": "Relic",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.58",
-              "roll": {
-                "min": 59,
-                "max": 59
-              },
-              "text": "Span",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.59",
-              "roll": {
-                "min": 60,
-                "max": 60
-              },
-              "text": "Formation",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.60",
-              "roll": {
-                "min": 61,
-                "max": 61
-              },
-              "text": "Nest",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.61",
-              "roll": {
-                "min": 62,
-                "max": 62
-              },
-              "text": "Treasure",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.62",
-              "roll": {
-                "min": 63,
-                "max": 63
-              },
-              "text": "Prominence",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.63",
-              "roll": {
-                "min": 64,
-                "max": 64
-              },
-              "text": "Predator",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.64",
-              "roll": {
-                "min": 65,
-                "max": 65
-              },
-              "text": "Trap",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.65",
-              "roll": {
-                "min": 66,
-                "max": 66
-              },
-              "text": "People",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.66",
-              "roll": {
-                "min": 67,
-                "max": 67
-              },
-              "text": "Tracks",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.67",
-              "roll": {
-                "min": 68,
-                "max": 68
-              },
-              "text": "Combatant",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.68",
-              "roll": {
-                "min": 69,
-                "max": 69
-              },
-              "text": "Storage",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.69",
-              "roll": {
-                "min": 70,
-                "max": 70
-              },
-              "text": "Riches",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.70",
-              "roll": {
-                "min": 71,
-                "max": 71
-              },
-              "text": "Anomaly",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.71",
-              "roll": {
-                "min": 72,
-                "max": 72
-              },
-              "text": "Outpost",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.72",
-              "roll": {
-                "min": 73,
-                "max": 73
-              },
-              "text": "Settlement",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.73",
-              "roll": {
-                "min": 74,
-                "max": 74
-              },
-              "text": "Cultivation",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.74",
-              "roll": {
-                "min": 75,
-                "max": 75
-              },
-              "text": "Craftwork",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.75",
-              "roll": {
-                "min": 76,
-                "max": 76
-              },
-              "text": "Caravan",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.76",
-              "roll": {
-                "min": 77,
-                "max": 77
-              },
-              "text": "Void",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.77",
-              "roll": {
-                "min": 78,
-                "max": 78
-              },
-              "text": "Fire",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.78",
-              "roll": {
-                "min": 79,
-                "max": 79
-              },
-              "text": "Smell",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.79",
-              "roll": {
-                "min": 80,
-                "max": 80
-              },
-              "text": "Remains",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.80",
-              "roll": {
-                "min": 81,
-                "max": 81
-              },
-              "text": "Artifact",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.81",
-              "roll": {
-                "min": 82,
-                "max": 82
-              },
-              "text": "Energy",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.82",
-              "roll": {
-                "min": 83,
-                "max": 83
-              },
-              "text": "Puzzle",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.83",
-              "roll": {
-                "min": 84,
-                "max": 84
-              },
-              "text": "Equipment",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.84",
-              "roll": {
-                "min": 85,
-                "max": 85
-              },
-              "text": "Discovery",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.85",
-              "roll": {
-                "min": 86,
-                "max": 86
-              },
-              "text": "Apparition",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.86",
-              "roll": {
-                "min": 87,
-                "max": 87
-              },
-              "text": "Remnant",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.87",
-              "roll": {
-                "min": 88,
-                "max": 88
-              },
-              "text": "Guardian",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.88",
-              "roll": {
-                "min": 89,
-                "max": 89
-              },
-              "text": "Shrine",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.89",
-              "roll": {
-                "min": 90,
-                "max": 90
-              },
-              "text": "Barricade",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.90",
-              "roll": {
-                "min": 91,
-                "max": 91
-              },
-              "text": "Insects",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.91",
-              "roll": {
-                "min": 92,
-                "max": 92
-              },
-              "text": "Waterway",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.92",
-              "roll": {
-                "min": 93,
-                "max": 93
-              },
-              "text": "Material",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.93",
-              "roll": {
-                "min": 94,
-                "max": 94
-              },
-              "text": "Worksite",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.94",
-              "roll": {
-                "min": 95,
-                "max": 95
-              },
-              "text": "Mire",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.95",
-              "roll": {
-                "min": 96,
-                "max": 96
-              },
-              "text": "Lair",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.96",
-              "roll": {
-                "min": 97,
-                "max": 97
-              },
-              "text": "Obstacle",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.97",
-              "roll": {
-                "min": 98,
-                "max": 98
-              },
-              "text": "Wood",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.98",
-              "roll": {
-                "min": 99,
-                "max": 99
-              },
-              "text": "Animal",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/core/focus.99",
-              "roll": {
-                "min": 100,
-                "max": 100
-              },
-              "text": "Corpse",
-              "_i18n": {
-                "text": {
-                  "part_of_speech": "common_noun"
-                }
-              }
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 53,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn: Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 50,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "magic": {
-      "_id": "oracle_collection:lodestar/magic",
-      "type": "oracle_collection",
-      "name": "Magic Oracles",
-      "oracle_type": "tables",
-      "contents": {
-        "ritual_backlash": {
-          "_id": "oracle_rollable:lodestar/magic/ritual_backlash",
-          "type": "oracle_rollable",
-          "name": "Ritual Backlash",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Those who deal in magic may find themselves at the mercy of chaos. This oracle can supplement, or replace, the Pay the Price table when resolving the outcome of a failed ritual or other negative interaction with mystical forces. Use this oracle in dramatic moments, or to introduce an unexpected outcome triggered by a match.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.0",
-              "roll": {
-                "min": 1,
-                "max": 4
-              },
-              "text": "Your ritual has the opposite effect."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.1",
-              "roll": {
-                "min": 5,
-                "max": 8
-              },
-              "text": "You are sapped of strength."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.2",
-              "roll": {
-                "min": 9,
-                "max": 12
-              },
-              "text": "Your friend, ally, or companion is adversely affected."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.3",
-              "roll": {
-                "min": 13,
-                "max": 16
-              },
-              "text": "You destroy an important object."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.4",
-              "roll": {
-                "min": 17,
-                "max": 20
-              },
-              "text": "You inadvertently summon a spirit or undead being."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.5",
-              "roll": {
-                "min": 21,
-                "max": 24
-              },
-              "text": "You collapse, and drift into a troubled sleep."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.6",
-              "roll": {
-                "min": 25,
-                "max": 28
-              },
-              "text": "You undergo a physical torment which leaves its mark upon you."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.7",
-              "roll": {
-                "min": 29,
-                "max": 32
-              },
-              "text": "You hear ghostly voices whispering of dark portents."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.8",
-              "roll": {
-                "min": 33,
-                "max": 36
-              },
-              "text": "You find yourself in another place without memory of how you got there."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.9",
-              "roll": {
-                "min": 37,
-                "max": 40
-              },
-              "text": "You alert someone or something to your presence."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.10",
-              "roll": {
-                "min": 41,
-                "max": 44
-              },
-              "text": "You are not yourself, and act against a friend, ally, or companion."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.11",
-              "roll": {
-                "min": 45,
-                "max": 48
-              },
-              "text": "You affect your surroundings, causing a disturbance or potential harm."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.12",
-              "roll": {
-                "min": 49,
-                "max": 52
-              },
-              "text": "You waste resources."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.13",
-              "roll": {
-                "min": 53,
-                "max": 56
-              },
-              "text": "You suffer the loss of a sense for several hours."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.14",
-              "roll": {
-                "min": 57,
-                "max": 60
-              },
-              "text": "You lose your connection to magic for a day or so."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.15",
-              "roll": {
-                "min": 61,
-                "max": 64
-              },
-              "text": "Your ritual affects the target in an unexpected and problematic way."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.16",
-              "roll": {
-                "min": 65,
-                "max": 68
-              },
-              "text": "Your ritual reveals a surprising and troubling truth."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.17",
-              "roll": {
-                "min": 69,
-                "max": 72
-              },
-              "text": "You are tempted by dark powers."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.18",
-              "roll": {
-                "min": 73,
-                "max": 76
-              },
-              "text": "You see a troubling vision of your future."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.19",
-              "roll": {
-                "min": 77,
-                "max": 80
-              },
-              "text": "You can't perform this ritual again until you acquire a key component."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.20",
-              "roll": {
-                "min": 81,
-                "max": 84
-              },
-              "text": "You develop a strange fear or compulsion."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.21",
-              "roll": {
-                "min": 85,
-                "max": 88
-              },
-              "text": "Your ritual causes creatures to exhibit strange or aggressive behavior."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.22",
-              "roll": {
-                "min": 89,
-                "max": 92
-              },
-              "text": "You are tormented by an apparition from your past."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.23",
-              "roll": {
-                "min": 93,
-                "max": 96
-              },
-              "text": "You are wracked with sudden sickness."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.24",
-              "roll": {
-                "min": 97,
-                "max": 100
-              },
-              "text": "Roll twice; if they are the same result, make it worse.",
-              "oracle_rolls": [
-                {
-                  "oracle": null,
-                  "dice": null,
-                  "auto": true,
-                  "duplicates": "make_it_worse",
-                  "number_of_rolls": 2
-                }
-              ]
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 96,
-            "url": "https://ironswornrpg.com"
-          }
-        },
-        "mystic_effect": {
-          "_id": "oracle_rollable:lodestar/magic/mystic_effect",
-          "type": "oracle_rollable",
-          "name": "Mystic Effect",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Use this oracle to reveal the nature or outcome of a mystic power, ritual effect, or supernatural phenomenon.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.0",
-              "roll": {
-                "min": 1,
-                "max": 6
-              },
-              "text": "Drain the life from a target."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.1",
-              "roll": {
-                "min": 7,
-                "max": 8
-              },
-              "text": "Disintegrate or decay objects."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.2",
-              "roll": {
-                "min": 9,
-                "max": 10
-              },
-              "text": "Awaken an ancient being."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.3",
-              "roll": {
-                "min": 11,
-                "max": 12
-              },
-              "text": "Summon a monstrous creature."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.4",
-              "roll": {
-                "min": 13,
-                "max": 14
-              },
-              "text": "Bind to a vow or task."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.5",
-              "roll": {
-                "min": 15,
-                "max": 16
-              },
-              "text": "Give life to inanimate forms."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.6",
-              "roll": {
-                "min": 17,
-                "max": 18
-              },
-              "text": "Unleash a plague."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.7",
-              "roll": {
-                "min": 19,
-                "max": 20
-              },
-              "text": "Control elemental forces."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.8",
-              "roll": {
-                "min": 21,
-                "max": 22
-              },
-              "text": "Erase or suppress memories."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.9",
-              "roll": {
-                "min": 23,
-                "max": 24
-              },
-              "text": "Shroud in lasting darkness."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.10",
-              "roll": {
-                "min": 25,
-                "max": 26
-              },
-              "text": "Alter surrounding environment."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.11",
-              "roll": {
-                "min": 27,
-                "max": 28
-              },
-              "text": "Bind to a location."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.12",
-              "roll": {
-                "min": 29,
-                "max": 30
-              },
-              "text": "Inflict cursed luck."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.13",
-              "roll": {
-                "min": 31,
-                "max": 32
-              },
-              "text": "Incite negative emotions."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.14",
-              "roll": {
-                "min": 33,
-                "max": 34
-              },
-              "text": "Awaken latent powers in another."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.15",
-              "roll": {
-                "min": 35,
-                "max": 36
-              },
-              "text": "Inflict aging or wasting."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.16",
-              "roll": {
-                "min": 37,
-                "max": 38
-              },
-              "text": "Bind to a restless spirit."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.17",
-              "roll": {
-                "min": 39,
-                "max": 40
-              },
-              "text": "Grant horrifying knowledge."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.18",
-              "roll": {
-                "min": 41,
-                "max": 42
-              },
-              "text": "Awaken or animate the dead."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.19",
-              "roll": {
-                "min": 43,
-                "max": 44
-              },
-              "text": "Incite an obsession."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.20",
-              "roll": {
-                "min": 45,
-                "max": 46
-              },
-              "text": "Manifest inner fears."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.21",
-              "roll": {
-                "min": 47,
-                "max": 48
-              },
-              "text": "Reveal hidden truths."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.22",
-              "roll": {
-                "min": 49,
-                "max": 50
-              },
-              "text": "Commune with spirits."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.23",
-              "roll": {
-                "min": 51,
-                "max": 52
-              },
-              "text": "Control weather or environment."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.24",
-              "roll": {
-                "min": 53,
-                "max": 54
-              },
-              "text": "Reveal past events."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.25",
-              "roll": {
-                "min": 55,
-                "max": 56
-              },
-              "text": "Emit destructive energies."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.26",
-              "roll": {
-                "min": 57,
-                "max": 58
-              },
-              "text": "Alter the flow of time."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.27",
-              "roll": {
-                "min": 59,
-                "max": 60
-              },
-              "text": "Inflict a consuming need."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.28",
-              "roll": {
-                "min": 61,
-                "max": 62
-              },
-              "text": "Create hallucinations or illusions."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.29",
-              "roll": {
-                "min": 63,
-                "max": 64
-              },
-              "text": "Trigger a celestial event."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.30",
-              "roll": {
-                "min": 65,
-                "max": 66
-              },
-              "text": "Summon a swarm of creatures."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.31",
-              "roll": {
-                "min": 67,
-                "max": 68
-              },
-              "text": "Reveal distant places."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.32",
-              "roll": {
-                "min": 69,
-                "max": 70
-              },
-              "text": "Absorb energy or essence."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.33",
-              "roll": {
-                "min": 71,
-                "max": 72
-              },
-              "text": "Banish to another reality."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.34",
-              "roll": {
-                "min": 73,
-                "max": 74
-              },
-              "text": "Banish to another location."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.35",
-              "roll": {
-                "min": 75,
-                "max": 76
-              },
-              "text": "Inflict prophetic visions."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.36",
-              "roll": {
-                "min": 77,
-                "max": 78
-              },
-              "text": "Inflict dreadful transformations."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.37",
-              "roll": {
-                "min": 79,
-                "max": 80
-              },
-              "text": "Inflict sickness or weakness."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.38",
-              "roll": {
-                "min": 81,
-                "max": 82
-              },
-              "text": "Absorb life."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.39",
-              "roll": {
-                "min": 83,
-                "max": 84
-              },
-              "text": "Spread corruption or blight."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.40",
-              "roll": {
-                "min": 85,
-                "max": 86
-              },
-              "text": "Brand with a cursed mark."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.41",
-              "roll": {
-                "min": 87,
-                "max": 88
-              },
-              "text": "Destroy terrain or architecture."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.42",
-              "roll": {
-                "min": 89,
-                "max": 90
-              },
-              "text": "Grant a lasting boon—at a cost."
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/magic/mystic_effect.43",
-              "roll": {
-                "min": 91,
-                "max": 100
-              },
-              "text": "Roll twice.",
-              "oracle_rolls": [
-                {
-                  "oracle": null,
-                  "dice": null,
-                  "auto": true,
-                  "duplicates": "reroll",
-                  "number_of_rolls": 2
-                }
-              ]
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 97,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn: Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 96,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "scale": {
-      "_id": "oracle_collection:lodestar/scale",
-      "type": "oracle_collection",
-      "name": "Scale Oracles",
-      "oracle_type": "tables",
-      "summary": "Use these oracles to help answer a question related to the scale, extent, or capability of something.",
-      "contents": {
-        "rank": {
-          "_id": "oracle_rollable:lodestar/scale/rank",
-          "type": "oracle_rollable",
-          "name": "Rank",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "Use this oracle to randomly set the challenge rank of a quest, journey, or foe.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/scale/rank.0",
-              "roll": {
-                "min": 1,
-                "max": 15
-              },
-              "text": "Troublesome"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/scale/rank.1",
-              "roll": {
-                "min": 16,
-                "max": 35
-              },
-              "text": "Dangerous"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/scale/rank.2",
-              "roll": {
-                "min": 36,
-                "max": 65
-              },
-              "text": "Formidable"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/scale/rank.3",
-              "roll": {
-                "min": 66,
-                "max": 85
-              },
-              "text": "Extreme"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/scale/rank.4",
-              "roll": {
-                "min": 86,
-                "max": 100
-              },
-              "text": "Epic"
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 99,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "collections": {
-        "magnitude": {
-          "_id": "oracle_collection:lodestar/scale/magnitude",
-          "type": "oracle_collection",
-          "name": "Magnitude",
-          "oracle_type": "tables",
-          "summary": "Ask your question, choose one of the following tables, and roll to reveal the answer.",
-          "contents": {
-            "size": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/size",
-              "type": "oracle_rollable",
-              "name": "Size",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/size.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Undersized"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/size.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Small"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/size.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Medium"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/size.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Large"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/size.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Huge"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "number": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/number",
-              "type": "oracle_rollable",
-              "name": "Number",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/number.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "None / one"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/number.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Few"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/number.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Several"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/number.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Many"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/number.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Countless"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "distance": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/distance",
-              "type": "oracle_rollable",
-              "name": "Distance",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Very close"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Near"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Far"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Remote"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Inaccessible"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "time": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/time",
-              "type": "oracle_rollable",
-              "name": "Time",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/time.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Fleeting"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/time.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Short"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/time.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Moderate"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/time.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Lengthy"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/time.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Eternal"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "power": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/power",
-              "type": "oracle_rollable",
-              "name": "Power",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/power.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Weak"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/power.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Minor"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/power.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Capable"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/power.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Strong"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/power.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Overwhelming"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "complexity": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/complexity",
-              "type": "oracle_rollable",
-              "name": "Complexity",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Simple"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Basic"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Manageable"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Complicated"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Bewildering"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "value": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/value",
-              "type": "oracle_rollable",
-              "name": "Value",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/value.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Worthless"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/value.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Cheap"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/value.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Common"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/value.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Valuable"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/value.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Priceless"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "influence": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/influence",
-              "type": "oracle_rollable",
-              "name": "Influence",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Limited"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Isolated"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Localized"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Far-reaching"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Dominant"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            },
-            "disposition": {
-              "_id": "oracle_rollable:lodestar/scale/magnitude/disposition",
-              "type": "oracle_rollable",
-              "name": "Disposition",
-              "oracle_type": "table_text",
-              "dice": "1d100",
-              "column_labels": {
-                "roll": "Roll",
-                "text": "Result"
-              },
-              "rows": [
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.0",
-                  "roll": {
-                    "min": 1,
-                    "max": 15
-                  },
-                  "text": "Friendly"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.1",
-                  "roll": {
-                    "min": 16,
-                    "max": 35
-                  },
-                  "text": "Open"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.2",
-                  "roll": {
-                    "min": 36,
-                    "max": 65
-                  },
-                  "text": "Wary"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.3",
-                  "roll": {
-                    "min": 66,
-                    "max": 85
-                  },
-                  "text": "Threatening"
-                },
-                {
-                  "_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.4",
-                  "roll": {
-                    "min": 86,
-                    "max": 100
-                  },
-                  "text": "Hostile"
-                }
-              ],
-              "_source": {
-                "title": "Ironsworn: Lodestar",
-                "authors": [
-                  {
-                    "name": "Shawn Tomkin"
-                  }
-                ],
-                "date": "2025-05-01",
-                "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-                "page": 98,
-                "url": "https://ironswornrpg.com"
-              }
-            }
-          },
-          "collections": {},
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 98,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "_source": {
-        "title": "Ironsworn: Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 98,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "story": {
-      "_id": "oracle_collection:lodestar/story",
-      "type": "oracle_collection",
-      "name": "Story Oracles",
-      "oracle_type": "tables",
-      "contents": {
-        "clue": {
-          "_id": "oracle_rollable:lodestar/story/clue",
-          "type": "oracle_rollable",
-          "name": "Clue",
-          "oracle_type": "table_text",
-          "dice": "1d100",
-          "summary": "When you investigate a mystery, you might uncover clues in the form of messages, rumors, eyewitness reports, supernatural revelations, or physical evidence. Use this oracle to help reveal what this evidence connects to or implicates.",
-          "column_labels": {
-            "roll": "Roll",
-            "text": "Result"
-          },
-          "rows": [
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.0",
-              "roll": {
-                "min": 1,
-                "max": 3
-              },
-              "text": "Affirms a previously understood fact or clue"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.1",
-              "roll": {
-                "min": 4,
-                "max": 6
-              },
-              "text": "Connects to a known rumor or scandal"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.2",
-              "roll": {
-                "min": 7,
-                "max": 9
-              },
-              "text": "Connects to a previously unrelated mystery or quest"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.3",
-              "roll": {
-                "min": 10,
-                "max": 12
-              },
-              "text": "Connects to your own expertise or interests"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.4",
-              "roll": {
-                "min": 13,
-                "max": 15
-              },
-              "text": "Contradicts a previously understood fact or clue"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.5",
-              "roll": {
-                "min": 16,
-                "max": 18
-              },
-              "text": "Evokes a personal memory"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.6",
-              "roll": {
-                "min": 19,
-                "max": 21
-              },
-              "text": "Evokes a legend or prophecy"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.7",
-              "roll": {
-                "min": 22,
-                "max": 24
-              },
-              "text": "Evokes a dream or vision"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.8",
-              "roll": {
-                "min": 25,
-                "max": 27
-              },
-              "text": "Involves a hidden or mysterious community"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.9",
-              "roll": {
-                "min": 28,
-                "max": 30
-              },
-              "text": "Involves a hidden or mysterious person"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.10",
-              "roll": {
-                "min": 31,
-                "max": 33
-              },
-              "text": "Involves a nonhuman being or entity"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.11",
-              "roll": {
-                "min": 34,
-                "max": 36
-              },
-              "text": "Involves a creature"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.12",
-              "roll": {
-                "min": 37,
-                "max": 39
-              },
-              "text": "Involves an artifact or precious object"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.13",
-              "roll": {
-                "min": 40,
-                "max": 42
-              },
-              "text": "Involves a personal item"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.14",
-              "roll": {
-                "min": 43,
-                "max": 45
-              },
-              "text": "Involves a weapon"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.15",
-              "roll": {
-                "min": 46,
-                "max": 48
-              },
-              "text": "Involves a valuable resource"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.16",
-              "roll": {
-                "min": 49,
-                "max": 51
-              },
-              "text": "Involves a notable community or faction"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.17",
-              "roll": {
-                "min": 52,
-                "max": 54
-              },
-              "text": "Involves a leader or notable person"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.18",
-              "roll": {
-                "min": 55,
-                "max": 57
-              },
-              "text": "Involves a person or community from your background"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.19",
-              "roll": {
-                "min": 58,
-                "max": 60
-              },
-              "text": "Involves an enemy or rival"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.20",
-              "roll": {
-                "min": 61,
-                "max": 63
-              },
-              "text": "Involves someone you trust"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.21",
-              "roll": {
-                "min": 64,
-                "max": 65
-              },
-              "text": "Involves a mystic power or ritual"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.22",
-              "roll": {
-                "min": 66,
-                "max": 68
-              },
-              "text": "Involves an ailment or affliction"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.23",
-              "roll": {
-                "min": 69,
-                "max": 71
-              },
-              "text": "Involves a religion or belief"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.24",
-              "roll": {
-                "min": 72,
-                "max": 74
-              },
-              "text": "Involves a promise or debt"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.25",
-              "roll": {
-                "min": 75,
-                "max": 77
-              },
-              "text": "Leads to a nearby or familiar place"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.26",
-              "roll": {
-                "min": 78,
-                "max": 80
-              },
-              "text": "Leads to an ancient or ruined place"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.27",
-              "roll": {
-                "min": 81,
-                "max": 83
-              },
-              "text": "Leads to a settled place"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.28",
-              "roll": {
-                "min": 84,
-                "max": 86
-              },
-              "text": "Leads to a remote or wild place"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.29",
-              "roll": {
-                "min": 87,
-                "max": 89
-              },
-              "text": "Leads to a notable landmark"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.30",
-              "roll": {
-                "min": 90,
-                "max": 91
-              },
-              "text": "Leads to a mystical or unearthly place"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.31",
-              "roll": {
-                "min": 92,
-                "max": 94
-              },
-              "text": "Suggests a history of similar incidents"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.32",
-              "roll": {
-                "min": 95,
-                "max": 97
-              },
-              "text": "Suggests a looming event or deadline"
-            },
-            {
-              "_id": "oracle_rollable.row:lodestar/story/clue.33",
-              "roll": {
-                "min": 98,
-                "max": 100
-              },
-              "text": "Suggests an imposter or deception"
-            }
-          ],
-          "_source": {
-            "title": "Ironsworn: Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 93,
-            "url": "https://ironswornrpg.com"
-          }
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn: Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 92,
-        "url": "https://ironswornrpg.com"
-      }
-    }
-  },
-  "assets": {},
-  "atlas": {},
-  "moves": {
-    "journey": {
-      "_id": "move_category:lodestar/journey",
-      "type": "move_category",
-      "name": "Journey Moves",
-      "enhances": ["move_category:classic/adventure"],
-      "summary": "Journey moves are used as you travel across the Ironlands.",
-      "contents": {
-        "follow_a_path": {
-          "_id": "move:lodestar/journey/follow_a_path",
-          "type": "move",
-          "name": "Follow a Path",
-          "roll_type": "action_roll",
-          "trigger": {
-            "conditions": [
-              {
-                "_id": "move.condition:lodestar/journey/follow_a_path.0",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "condition_meter",
-                    "condition_meter": "supply"
-                  }
-                ]
-              }
-            ],
-            "text": "When you journey along a known route, and one day blends into the next..."
-          },
-          "text": "When __you journey along a known route, and one day blends into the next__, roll +supply.\n\nOn a __strong hit__, you reach your destination and the situation favors you. Take +1 momentum.\n\nOn a __weak hit__, you complete the journey, but face a cost or complication. Choose one or more.\n\n  * You took longer than expected.\n  * You pressed on through pain, sickness, or weariness: [Endure Harm](datasworn:move:classic/suffer/endure_harm).\n  * You suffered under the burden of foul weather, worries, or fearful locations: [Endure Stress](datasworn:move:classic/suffer/endure_stress).\n  * You wasted resources.\n  * You face a complication or hazard at the destination. Envision what you find ([Ask the Oracle](datasworn:move:classic/fate/ask_the_oracle) if unsure).\n\nOn a __miss__, you are waylaid by a dire threat and must [Pay the Price](datasworn:move:classic/fate/pay_the_price). If you overcome this obstacle, you may push on safely to your destination.",
-          "outcomes": {
-            "strong_hit": {
-              "_id": "move.outcome:lodestar/journey/follow_a_path.strong_hit",
-              "text": "On a __strong hit__, you reach your destination and the situation favors you. Take +1 momentum."
-            },
-            "weak_hit": {
-              "_id": "move.outcome:lodestar/journey/follow_a_path.weak_hit",
-              "text": "On a __weak hit__, you complete the journey, but face a cost or complication. Choose one or more.\n\n  * You took longer than expected.\n  * You pressed on through pain, sickness, or weariness: [Endure Harm](datasworn:move:classic/suffer/endure_harm).\n  * You suffered under the burden of foul weather, worries, or fearful locations: [Endure Stress](datasworn:move:classic/suffer/endure_stress).\n  * You wasted resources.\n  * You face a complication or hazard at the destination. Envision what you find ([Ask the Oracle](datasworn:move:classic/fate/ask_the_oracle) if unsure)."
-            },
-            "miss": {
-              "_id": "move.outcome:lodestar/journey/follow_a_path.miss",
-              "text": "On a __miss__, you are waylaid by a dire threat and must [Pay the Price](datasworn:move:classic/fate/pay_the_price). If you overcome this obstacle, you may push on safely to your destination."
-            }
-          },
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 10,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": true
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 10,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "adventure": {
-      "_id": "move_category:lodestar/adventure",
-      "type": "move_category",
-      "name": "Adventure Moves",
-      "enhances": ["move_category:classic/adventure"],
-      "contents": {
-        "face_danger": {
-          "_id": "move:lodestar/adventure/face_danger",
-          "type": "move",
-          "name": "Face Danger",
-          "roll_type": "action_roll",
-          "replaces": ["move:classic/adventure/face_danger"],
-          "trigger": {
-            "conditions": [
-              {
-                "_id": "move.condition:lodestar/adventure/face_danger.0",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "edge"
-                  }
-                ],
-                "text": "With speed, agility, or precision"
-              },
-              {
-                "_id": "move.condition:lodestar/adventure/face_danger.1",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "heart"
-                  }
-                ],
-                "text": "With charm, loyalty, or courage"
-              },
-              {
-                "_id": "move.condition:lodestar/adventure/face_danger.2",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "iron"
-                  }
-                ],
-                "text": "With aggressive action, forceful defense, strength, or endurance"
-              },
-              {
-                "_id": "move.condition:lodestar/adventure/face_danger.3",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "shadow"
-                  }
-                ],
-                "text": "With deception, stealth, or trickery"
-              },
-              {
-                "_id": "move.condition:lodestar/adventure/face_danger.4",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "wits"
-                  }
-                ],
-                "text": "With expertise, insight, or observation"
-              }
-            ],
-            "text": "When you attempt something risky or react to an imminent threat..."
-          },
-          "text": "When __you attempt something risky or react to an imminent threat__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, you are successful. Take +1 momentum.\n\nOn a __weak hit__, you succeed, but face a troublesome cost. Choose one.\n\n  * You are delayed, lose advantage, or face a new danger: Suffer -1 momentum.\n  * You are tired or hurt: [Endure Harm](datasworn:move:classic/suffer/endure_harm) (1 harm).\n  * You are dispirited or afraid: [Endure Stress](datasworn:move:classic/suffer/endure_stress) (1 stress).\n  * You sacrifice resources: Suffer -1 supply.\n\nOn a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
-          "outcomes": {
-            "strong_hit": {
-              "_id": "move.outcome:lodestar/adventure/face_danger.strong_hit",
-              "text": "On a __strong hit__, you are successful. Take +1 momentum."
-            },
-            "weak_hit": {
-              "_id": "move.outcome:lodestar/adventure/face_danger.weak_hit",
-              "text": "On a __weak hit__, you succeed, but face a troublesome cost. Choose one.\n\n  * You are delayed, lose advantage, or face a new danger: Suffer -1 momentum.\n  * You are tired or hurt: [Endure Harm](datasworn:move:classic/suffer/endure_harm) (1 harm).\n  * You are dispirited or afraid: [Endure Stress](datasworn:move:classic/suffer/endure_stress) (1 stress).\n  * You sacrifice resources: Suffer -1 supply."
-            },
-            "miss": {
-              "_id": "move.outcome:lodestar/adventure/face_danger.miss",
-              "text": "On a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
-            }
-          },
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 8,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": true
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 8,
-        "url": "https://ironswornrpg.com"
-      }
-    },
-    "scene_challenge": {
-      "_id": "move_category:lodestar/scene_challenge",
-      "type": "move_category",
-      "name": "Scene Challenge Moves",
-      "summary": "A scene challenge is an optional approach you can use to resolve an extended challenge against an obstacle or NPCs.",
-      "contents": {
-        "begin_the_scene": {
-          "_id": "move:lodestar/scene_challenge/begin_the_scene",
-          "type": "move",
-          "name": "Begin the Scene",
-          "roll_type": "no_roll",
-          "trigger": {
-            "conditions": [],
-            "text": "When you face an extended or complex challenge..."
-          },
-          "text": "When __you face an extended or complex challenge__, name your objective and choose a rank as appropriate to the situation.\n\n  * You have a clear advantage: Troublesome\n  * You are ready to act: Dangerous\n  * You are unprepared or outmatched: Formidable\n\nThen, activate a four-segment countdown track and [Face Danger](datasworn:move:lodestar/scene_challenge/face_danger) or [Secure an Advantage](datasworn:move:lodestar/scene_challenge/secure_an_advantage) to take action.",
-          "outcomes": null,
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 11,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": false
-        },
-        "face_danger": {
-          "_id": "move:lodestar/scene_challenge/face_danger",
-          "type": "move",
-          "name": "Face Danger (Scene Challenge)",
-          "roll_type": "action_roll",
-          "trigger": {
-            "conditions": [
-              {
-                "_id": "move.condition:lodestar/scene_challenge/face_danger.0",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "edge"
-                  }
-                ],
-                "text": "With speed, mobility, or agility"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/face_danger.1",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "heart"
-                  }
-                ],
-                "text": "With charm, loyalty, or courage"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/face_danger.2",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "iron"
-                  }
-                ],
-                "text": "With aggressive action, forceful defense, strength, or endurance"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/face_danger.3",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "shadow"
-                  }
-                ],
-                "text": "With deception, stealth, or trickery"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/face_danger.4",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "wits"
-                  }
-                ],
-                "text": "With expertise, insight, or observation"
-              }
-            ],
-            "text": "When you attempt something risky or react to an imminent threat within a scene challenge..."
-          },
-          "text": "When __you attempt something risky or react to an imminent threat within a scene challenge__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, you are successful and mark progress. On a __strong hit with a match__, mark progress twice.\n\nOn a __weak hit__, you are successful and mark progress, but also encounter a complication or setback. Envision what occurs and mark a countdown segment.\n\nOn a __miss__, you fail, or a momentary success is undermined by a dramatic turn of events. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
-          "outcomes": {
-            "strong_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/face_danger.strong_hit",
-              "text": "On a __strong hit__, you are successful and mark progress. On a __strong hit with a match__, mark progress twice."
-            },
-            "weak_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/face_danger.weak_hit",
-              "text": "On a __weak hit__, you are successful and mark progress, but also encounter a complication or setback. Envision what occurs and mark a countdown segment."
-            },
-            "miss": {
-              "_id": "move.outcome:lodestar/scene_challenge/face_danger.miss",
-              "text": "On a __miss__, you fail, or a momentary success is undermined by a dramatic turn of events. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
-            }
-          },
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 11,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": true
-        },
-        "secure_an_advantage": {
-          "_id": "move:lodestar/scene_challenge/secure_an_advantage",
-          "type": "move",
-          "name": "Secure an Advantage (Scene Challenge)",
-          "roll_type": "action_roll",
-          "trigger": {
-            "conditions": [
-              {
-                "_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.0",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "edge"
-                  }
-                ],
-                "text": "With speed, agility, or precision"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.1",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "heart"
-                  }
-                ],
-                "text": "With charm, loyalty, or courage"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.2",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "iron"
-                  }
-                ],
-                "text": "With aggressive action, forceful defense, strength, or endurance"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.3",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "shadow"
-                  }
-                ],
-                "text": "With deception, stealth, or trickery"
-              },
-              {
-                "_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.4",
-                "method": "player_choice",
-                "roll_options": [
-                  {
-                    "using": "stat",
-                    "stat": "wits"
-                  }
-                ],
-                "text": "With expertise, insight, or observation"
-              }
-            ],
-            "text": "When you assess a situation, make preparations, or attempt to gain leverage within a scene challenge..."
-          },
-          "text": "When __you assess a situation, make preparations, or attempt to gain leverage__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, take both. On a __string hit with a match__, take both and mark progress. On a __weak hit__, choose one.\n\n  * Take +2 momentum\n  * Add +1 on your next move (not a progress move)\n\nOn a __miss__, you fail or your assumptions betray you. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
-          "outcomes": {
-            "strong_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.strong_hit",
-              "text": "On a __strong hit__, take +2 momentum and add +1 on your next move (not a progress move).\n\nOn a __strong hit with a match__, take +2 momentum, add +1 on your next move (not a progress move), and mark progress."
-            },
-            "weak_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.weak_hit",
-              "text": "On a __weak hit__, choose one.\n\n  * Take +2 momentum\n  * Add +1 on your next move (not a progress move)"
-            },
-            "miss": {
-              "_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.miss",
-              "text": "On a __miss__, you fail or your assumptions betray you. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
-            }
-          },
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 11,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": true
-        },
-        "finish_the_scene": {
-          "_id": "move:lodestar/scene_challenge/finish_the_scene",
-          "type": "move",
-          "name": "Finish the Scene",
-          "roll_type": "progress_roll",
-          "tracks": {
-            "category": "Scene Challenge",
-            "controls": {}
-          },
-          "trigger": {
-            "conditions": [
-              {
-                "_id": "move.condition:lodestar/scene_challenge/finish_the_scene.0",
-                "method": "progress_roll",
-                "roll_options": [
-                  {
-                    "using": "progress_track"
-                  }
-                ]
-              }
-            ],
-            "text": "When the scene challenge countdown track or progress track is filled, or when events lead to the scene’s conclusion..."
-          },
-          "text": "When __the scene challenge tension clock or progress track is filled, or when events lead to the scene’s conclusion__, roll the challenge dice and compare to your progress.\n\nOn a __strong hit__, you achieve your objective unconditionally.\n\nOn a __weak hit__, you succeed, but not without cost. You must [Pay the Price](datasworn:move:classic/fate/pay_the_price). Make this a minor cost relative to the scope of the scene.\n\nOn a __miss__, you fail or are undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
-          "outcomes": {
-            "strong_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.strong_hit",
-              "text": "On a __strong hit__, you achieve your objective unconditionally."
-            },
-            "weak_hit": {
-              "_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.weak_hit",
-              "text": "On a __weak hit__, you succeed, but not without cost. You must [Pay the Price](datasworn:move:classic/fate/pay_the_price). Make this a minor cost relative to the scope of the scene."
-            },
-            "miss": {
-              "_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.miss",
-              "text": "On a __miss__, you fail or are undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
-            }
-          },
-          "oracles": {},
-          "_source": {
-            "title": "Ironsworn Lodestar",
-            "authors": [
-              {
-                "name": "Shawn Tomkin"
-              }
-            ],
-            "date": "2025-05-01",
-            "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-            "page": 11,
-            "url": "https://ironswornrpg.com"
-          },
-          "allow_momentum_burn": false
-        }
-      },
-      "collections": {},
-      "_source": {
-        "title": "Ironsworn Lodestar",
-        "authors": [
-          {
-            "name": "Shawn Tomkin"
-          }
-        ],
-        "date": "2025-05-01",
-        "license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
-        "page": 11,
-        "url": "https://ironswornrpg.com"
-      }
-    }
-  },
-  "npcs": {},
-  "rarities": {},
-  "delve_sites": {},
-  "site_domains": {},
-  "site_themes": {},
-  "truths": {}
+	"_id": "lodestar",
+	"datasworn_version": "0.1.0",
+	"type": "expansion",
+	"ruleset": "classic",
+	"title": "Ironsworn Lodestar",
+	"authors": [
+		{
+			"name": "Shawn Tomkin"
+		}
+	],
+	"date": "2025-05-01",
+	"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+	"url": "https://ironswornrpg.com",
+	"oracles": {
+		"character": {
+			"_id": "oracle_collection:lodestar/character",
+			"type": "oracle_collection",
+			"name": "Character Oracles",
+			"oracle_type": "tables",
+			"enhances": [
+				"oracle_collection:classic/character",
+				"oracle_collection:delve/character"
+			],
+			"contents": {
+				"first_look": {
+					"_id": "oracle_rollable:lodestar/character/first_look",
+					"type": "oracle_rollable",
+					"name": "First Look",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to establish the first impression of a character you encounter.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.0",
+							"roll": {
+								"min": 1,
+								"max": 2
+							},
+							"text": "Well-armed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.1",
+							"roll": {
+								"min": 3,
+								"max": 4
+							},
+							"text": "Alluring",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.2",
+							"roll": {
+								"min": 5,
+								"max": 6
+							},
+							"text": "Mystical",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.3",
+							"roll": {
+								"min": 7,
+								"max": 8
+							},
+							"text": "Pursued",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.4",
+							"roll": {
+								"min": 9,
+								"max": 10
+							},
+							"text": "Beastly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.5",
+							"roll": {
+								"min": 11,
+								"max": 12
+							},
+							"text": "Stout",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.6",
+							"roll": {
+								"min": 13,
+								"max": 14
+							},
+							"text": "Confused",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.7",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Equipped",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.8",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Distressed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.9",
+							"roll": {
+								"min": 19,
+								"max": 20
+							},
+							"text": "Fearsome",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.10",
+							"roll": {
+								"min": 21,
+								"max": 22
+							},
+							"text": "Cloaked",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.11",
+							"roll": {
+								"min": 23,
+								"max": 24
+							},
+							"text": "Guarded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.12",
+							"roll": {
+								"min": 25,
+								"max": 26
+							},
+							"text": "Commanding",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.13",
+							"roll": {
+								"min": 27,
+								"max": 28
+							},
+							"text": "Weathered",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.14",
+							"roll": {
+								"min": 29,
+								"max": 30
+							},
+							"text": "Unassuming",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.15",
+							"roll": {
+								"min": 31,
+								"max": 32
+							},
+							"text": "Attractive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.16",
+							"roll": {
+								"min": 33,
+								"max": 34
+							},
+							"text": "Youthful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.17",
+							"roll": {
+								"min": 35,
+								"max": 36
+							},
+							"text": "Armored",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.18",
+							"roll": {
+								"min": 37,
+								"max": 38
+							},
+							"text": "Drunk",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.19",
+							"roll": {
+								"min": 39,
+								"max": 40
+							},
+							"text": "Silent",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.20",
+							"roll": {
+								"min": 41,
+								"max": 42
+							},
+							"text": "Brutish",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.21",
+							"roll": {
+								"min": 43,
+								"max": 44
+							},
+							"text": "Ghostly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.22",
+							"roll": {
+								"min": 45,
+								"max": 46
+							},
+							"text": "Sickly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.23",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Accented",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.24",
+							"roll": {
+								"min": 49,
+								"max": 50
+							},
+							"text": "Poised",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.25",
+							"roll": {
+								"min": 51,
+								"max": 52
+							},
+							"text": "Well-mannered",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.26",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Menacing",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.27",
+							"roll": {
+								"min": 55,
+								"max": 56
+							},
+							"text": "Filthy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.28",
+							"roll": {
+								"min": 57,
+								"max": 58
+							},
+							"text": "Wounded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.29",
+							"roll": {
+								"min": 59,
+								"max": 60
+							},
+							"text": "Mysterious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.30",
+							"roll": {
+								"min": 61,
+								"max": 62
+							},
+							"text": "Imposing",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.31",
+							"roll": {
+								"min": 63,
+								"max": 64
+							},
+							"text": "Ill-equipped",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.32",
+							"roll": {
+								"min": 65,
+								"max": 66
+							},
+							"text": "Scarred",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.33",
+							"roll": {
+								"min": 67,
+								"max": 68
+							},
+							"text": "Slight",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.34",
+							"roll": {
+								"min": 69,
+								"max": 70
+							},
+							"text": "Tattooed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.35",
+							"roll": {
+								"min": 71,
+								"max": 72
+							},
+							"text": "Grim",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.36",
+							"roll": {
+								"min": 73,
+								"max": 74
+							},
+							"text": "Masked",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.37",
+							"roll": {
+								"min": 75,
+								"max": 76
+							},
+							"text": "Distinguished",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.38",
+							"roll": {
+								"min": 77,
+								"max": 78
+							},
+							"text": "Fit",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.39",
+							"roll": {
+								"min": 79,
+								"max": 80
+							},
+							"text": "Firstborn",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.40",
+							"roll": {
+								"min": 81,
+								"max": 82
+							},
+							"text": "Bloodstained",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.41",
+							"roll": {
+								"min": 83,
+								"max": 84
+							},
+							"text": "Overburdened",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.42",
+							"roll": {
+								"min": 85,
+								"max": 86
+							},
+							"text": "Furtive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.43",
+							"roll": {
+								"min": 87,
+								"max": 88
+							},
+							"text": "Aged",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.44",
+							"roll": {
+								"min": 89,
+								"max": 90
+							},
+							"text": "Graceful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.45",
+							"roll": {
+								"min": 91,
+								"max": 92
+							},
+							"text": "Inhuman",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.46",
+							"roll": {
+								"min": 93,
+								"max": 94
+							},
+							"text": "Sinister",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.47",
+							"roll": {
+								"min": 95,
+								"max": 96
+							},
+							"text": "Visibly disabled",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.48",
+							"roll": {
+								"min": 97,
+								"max": 98
+							},
+							"text": "Concealed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/first_look.49",
+							"roll": {
+								"min": 99,
+								"max": 100
+							},
+							"text": "Uncanny",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 70,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"revealed_details": {
+					"_id": "oracle_rollable:lodestar/character/revealed_details",
+					"type": "oracle_rollable",
+					"name": "Revealed Details",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to reveal additional character traits and details as you get to know someone better.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.0",
+							"roll": {
+								"min": 1,
+								"max": 1
+							},
+							"text": "Stoic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.1",
+							"roll": {
+								"min": 2,
+								"max": 2
+							},
+							"text": "Attractive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.2",
+							"roll": {
+								"min": 3,
+								"max": 3
+							},
+							"text": "Passive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.3",
+							"roll": {
+								"min": 4,
+								"max": 4
+							},
+							"text": "Aloof",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.4",
+							"roll": {
+								"min": 5,
+								"max": 5
+							},
+							"text": "Affectionate",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.5",
+							"roll": {
+								"min": 6,
+								"max": 6
+							},
+							"text": "Generous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.6",
+							"roll": {
+								"min": 7,
+								"max": 7
+							},
+							"text": "Smug",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.7",
+							"roll": {
+								"min": 8,
+								"max": 8
+							},
+							"text": "Armed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.8",
+							"roll": {
+								"min": 9,
+								"max": 9
+							},
+							"text": "Clever",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.9",
+							"roll": {
+								"min": 10,
+								"max": 10
+							},
+							"text": "Brave",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.10",
+							"roll": {
+								"min": 11,
+								"max": 11
+							},
+							"text": "Ugly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.11",
+							"roll": {
+								"min": 12,
+								"max": 12
+							},
+							"text": "Sociable",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.12",
+							"roll": {
+								"min": 13,
+								"max": 13
+							},
+							"text": "Doomed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.13",
+							"roll": {
+								"min": 14,
+								"max": 14
+							},
+							"text": "Connected",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.14",
+							"roll": {
+								"min": 15,
+								"max": 15
+							},
+							"text": "Bold",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.15",
+							"roll": {
+								"min": 16,
+								"max": 16
+							},
+							"text": "Jealous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.16",
+							"roll": {
+								"min": 17,
+								"max": 17
+							},
+							"text": "Angry",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.17",
+							"roll": {
+								"min": 18,
+								"max": 18
+							},
+							"text": "Active",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.18",
+							"roll": {
+								"min": 19,
+								"max": 19
+							},
+							"text": "Suspicious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.19",
+							"roll": {
+								"min": 20,
+								"max": 20
+							},
+							"text": "Hostile",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.20",
+							"roll": {
+								"min": 21,
+								"max": 21
+							},
+							"text": "Hardhearted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.21",
+							"roll": {
+								"min": 22,
+								"max": 22
+							},
+							"text": "Successful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.22",
+							"roll": {
+								"min": 23,
+								"max": 23
+							},
+							"text": "Talented",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.23",
+							"roll": {
+								"min": 24,
+								"max": 24
+							},
+							"text": "Experienced",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.24",
+							"roll": {
+								"min": 25,
+								"max": 25
+							},
+							"text": "Deceitful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.25",
+							"roll": {
+								"min": 26,
+								"max": 26
+							},
+							"text": "Ambitious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.26",
+							"roll": {
+								"min": 27,
+								"max": 27
+							},
+							"text": "Aggressive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.27",
+							"roll": {
+								"min": 28,
+								"max": 28
+							},
+							"text": "Conceited",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.28",
+							"roll": {
+								"min": 29,
+								"max": 29
+							},
+							"text": "Proud",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.29",
+							"roll": {
+								"min": 30,
+								"max": 30
+							},
+							"text": "Stern",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.30",
+							"roll": {
+								"min": 31,
+								"max": 31
+							},
+							"text": "Dependent",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.31",
+							"roll": {
+								"min": 32,
+								"max": 32
+							},
+							"text": "Wary",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.32",
+							"roll": {
+								"min": 33,
+								"max": 33
+							},
+							"text": "Strong",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.33",
+							"roll": {
+								"min": 34,
+								"max": 34
+							},
+							"text": "Insightful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.34",
+							"roll": {
+								"min": 35,
+								"max": 35
+							},
+							"text": "Dangerous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.35",
+							"roll": {
+								"min": 36,
+								"max": 36
+							},
+							"text": "Quirky",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.36",
+							"roll": {
+								"min": 37,
+								"max": 37
+							},
+							"text": "Cheery",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.37",
+							"roll": {
+								"min": 38,
+								"max": 38
+							},
+							"text": "Disfigured",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.38",
+							"roll": {
+								"min": 39,
+								"max": 39
+							},
+							"text": "Intolerant",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.39",
+							"roll": {
+								"min": 40,
+								"max": 40
+							},
+							"text": "Skilled",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.40",
+							"roll": {
+								"min": 41,
+								"max": 41
+							},
+							"text": "Stingy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.41",
+							"roll": {
+								"min": 42,
+								"max": 42
+							},
+							"text": "Timid",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.42",
+							"roll": {
+								"min": 43,
+								"max": 43
+							},
+							"text": "Insensitive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.43",
+							"roll": {
+								"min": 44,
+								"max": 44
+							},
+							"text": "Wild",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.44",
+							"roll": {
+								"min": 45,
+								"max": 45
+							},
+							"text": "Bitter",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.45",
+							"roll": {
+								"min": 46,
+								"max": 46
+							},
+							"text": "Cunning",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.46",
+							"roll": {
+								"min": 47,
+								"max": 47
+							},
+							"text": "Remorseful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.47",
+							"roll": {
+								"min": 48,
+								"max": 48
+							},
+							"text": "Kind",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.48",
+							"roll": {
+								"min": 49,
+								"max": 49
+							},
+							"text": "Charming",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.49",
+							"roll": {
+								"min": 50,
+								"max": 50
+							},
+							"text": "Oblivious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.50",
+							"roll": {
+								"min": 51,
+								"max": 51
+							},
+							"text": "Critical",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.51",
+							"roll": {
+								"min": 52,
+								"max": 52
+							},
+							"text": "Cautious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.52",
+							"roll": {
+								"min": 53,
+								"max": 53
+							},
+							"text": "Resourceful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.53",
+							"roll": {
+								"min": 54,
+								"max": 54
+							},
+							"text": "Weary",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.54",
+							"roll": {
+								"min": 55,
+								"max": 55
+							},
+							"text": "Wounded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.55",
+							"roll": {
+								"min": 56,
+								"max": 56
+							},
+							"text": "Anxious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.56",
+							"roll": {
+								"min": 57,
+								"max": 57
+							},
+							"text": "Powerful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.57",
+							"roll": {
+								"min": 58,
+								"max": 58
+							},
+							"text": "Athletic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.58",
+							"roll": {
+								"min": 59,
+								"max": 59
+							},
+							"text": "Driven",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.59",
+							"roll": {
+								"min": 60,
+								"max": 60
+							},
+							"text": "Cruel",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.60",
+							"roll": {
+								"min": 61,
+								"max": 61
+							},
+							"text": "Quiet",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.61",
+							"roll": {
+								"min": 62,
+								"max": 62
+							},
+							"text": "Honest",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.62",
+							"roll": {
+								"min": 63,
+								"max": 63
+							},
+							"text": "Infamous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.63",
+							"roll": {
+								"min": 64,
+								"max": 64
+							},
+							"text": "Dying",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.64",
+							"roll": {
+								"min": 65,
+								"max": 65
+							},
+							"text": "Reclusive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.65",
+							"roll": {
+								"min": 66,
+								"max": 66
+							},
+							"text": "Artistic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.66",
+							"roll": {
+								"min": 67,
+								"max": 67
+							},
+							"text": "Disabled",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.67",
+							"roll": {
+								"min": 68,
+								"max": 68
+							},
+							"text": "Confused",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.68",
+							"roll": {
+								"min": 69,
+								"max": 69
+							},
+							"text": "Manipulative",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.69",
+							"roll": {
+								"min": 70,
+								"max": 70
+							},
+							"text": "Relaxed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.70",
+							"roll": {
+								"min": 71,
+								"max": 71
+							},
+							"text": "Stealthy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.71",
+							"roll": {
+								"min": 72,
+								"max": 72
+							},
+							"text": "Confident",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.72",
+							"roll": {
+								"min": 73,
+								"max": 73
+							},
+							"text": "Weak",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.73",
+							"roll": {
+								"min": 74,
+								"max": 74
+							},
+							"text": "Friendly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.74",
+							"roll": {
+								"min": 75,
+								"max": 75
+							},
+							"text": "Wise",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.75",
+							"roll": {
+								"min": 76,
+								"max": 76
+							},
+							"text": "Influential",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.76",
+							"roll": {
+								"min": 77,
+								"max": 77
+							},
+							"text": "Young",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.77",
+							"roll": {
+								"min": 78,
+								"max": 78
+							},
+							"text": "Adventurous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.78",
+							"roll": {
+								"min": 79,
+								"max": 79
+							},
+							"text": "Oppressed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.79",
+							"roll": {
+								"min": 80,
+								"max": 80
+							},
+							"text": "Vengeful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.80",
+							"roll": {
+								"min": 81,
+								"max": 81
+							},
+							"text": "Cooperative",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.81",
+							"roll": {
+								"min": 82,
+								"max": 82
+							},
+							"text": "Armored",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.82",
+							"roll": {
+								"min": 83,
+								"max": 83
+							},
+							"text": "Apathetic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.83",
+							"roll": {
+								"min": 84,
+								"max": 84
+							},
+							"text": "Determined",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.84",
+							"roll": {
+								"min": 85,
+								"max": 85
+							},
+							"text": "Loyal",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.85",
+							"roll": {
+								"min": 86,
+								"max": 86
+							},
+							"text": "Sick",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.86",
+							"roll": {
+								"min": 87,
+								"max": 87
+							},
+							"text": "Religious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.87",
+							"roll": {
+								"min": 88,
+								"max": 88
+							},
+							"text": "Selfish",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.88",
+							"roll": {
+								"min": 89,
+								"max": 89
+							},
+							"text": "Old",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.89",
+							"roll": {
+								"min": 90,
+								"max": 90
+							},
+							"text": "Fervent",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.90",
+							"roll": {
+								"min": 91,
+								"max": 91
+							},
+							"text": "Violent",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.91",
+							"roll": {
+								"min": 92,
+								"max": 92
+							},
+							"text": "Agreeable",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.92",
+							"roll": {
+								"min": 93,
+								"max": 93
+							},
+							"text": "Hot-tempered",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.93",
+							"roll": {
+								"min": 94,
+								"max": 94
+							},
+							"text": "Stubborn",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.94",
+							"roll": {
+								"min": 95,
+								"max": 95
+							},
+							"text": "Incompetent",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.95",
+							"roll": {
+								"min": 96,
+								"max": 96
+							},
+							"text": "Greedy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.96",
+							"roll": {
+								"min": 97,
+								"max": 97
+							},
+							"text": "Cowardly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.97",
+							"roll": {
+								"min": 98,
+								"max": 98
+							},
+							"text": "Obsessed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.98",
+							"roll": {
+								"min": 99,
+								"max": 99
+							},
+							"text": "Careless",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/character/revealed_details.99",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Ironsworn",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 72,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 70,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"name": {
+			"_id": "oracle_collection:lodestar/name",
+			"type": "oracle_collection",
+			"name": "Name Oracles",
+			"oracle_type": "tables",
+			"enhances": [
+				"oracle_collection:classic/name"
+			],
+			"contents": {
+				"ironlander_set_2": {
+					"_id": "oracle_rollable:lodestar/name/ironlander_set_2",
+					"type": "oracle_rollable",
+					"name": "Ironlander Names (Set 2)",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.0",
+							"roll": {
+								"min": 1,
+								"max": 1
+							},
+							"text": "Segura",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.1",
+							"roll": {
+								"min": 2,
+								"max": 2
+							},
+							"text": "Gethin",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.2",
+							"roll": {
+								"min": 3,
+								"max": 3
+							},
+							"text": "Bataar",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.3",
+							"roll": {
+								"min": 4,
+								"max": 4
+							},
+							"text": "Basira",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.4",
+							"roll": {
+								"min": 5,
+								"max": 5
+							},
+							"text": "Joa",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.5",
+							"roll": {
+								"min": 6,
+								"max": 6
+							},
+							"text": "Glynn",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.6",
+							"roll": {
+								"min": 7,
+								"max": 7
+							},
+							"text": "Toran",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.7",
+							"roll": {
+								"min": 8,
+								"max": 8
+							},
+							"text": "Arasen",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.8",
+							"roll": {
+								"min": 9,
+								"max": 9
+							},
+							"text": "Kuron",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.9",
+							"roll": {
+								"min": 10,
+								"max": 10
+							},
+							"text": "Griff",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.10",
+							"roll": {
+								"min": 11,
+								"max": 11
+							},
+							"text": "Owena",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.11",
+							"roll": {
+								"min": 12,
+								"max": 12
+							},
+							"text": "Adda",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.12",
+							"roll": {
+								"min": 13,
+								"max": 13
+							},
+							"text": "Euros",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.13",
+							"roll": {
+								"min": 14,
+								"max": 14
+							},
+							"text": "Kova",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.14",
+							"roll": {
+								"min": 15,
+								"max": 15
+							},
+							"text": "Kara",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.15",
+							"roll": {
+								"min": 16,
+								"max": 16
+							},
+							"text": "Morgan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.16",
+							"roll": {
+								"min": 17,
+								"max": 17
+							},
+							"text": "Nanda",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.17",
+							"roll": {
+								"min": 18,
+								"max": 18
+							},
+							"text": "Tamara",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.18",
+							"roll": {
+								"min": 19,
+								"max": 19
+							},
+							"text": "Asha",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.19",
+							"roll": {
+								"min": 20,
+								"max": 20
+							},
+							"text": "Delos",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.20",
+							"roll": {
+								"min": 21,
+								"max": 21
+							},
+							"text": "Torgan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.21",
+							"roll": {
+								"min": 22,
+								"max": 22
+							},
+							"text": "Makari",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.22",
+							"roll": {
+								"min": 23,
+								"max": 23
+							},
+							"text": "Selva",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.23",
+							"roll": {
+								"min": 24,
+								"max": 24
+							},
+							"text": "Kimura",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.24",
+							"roll": {
+								"min": 25,
+								"max": 25
+							},
+							"text": "Rhian",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.25",
+							"roll": {
+								"min": 26,
+								"max": 26
+							},
+							"text": "Tristan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.26",
+							"roll": {
+								"min": 27,
+								"max": 27
+							},
+							"text": "Siorra",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.27",
+							"roll": {
+								"min": 28,
+								"max": 28
+							},
+							"text": "Sayer",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.28",
+							"roll": {
+								"min": 29,
+								"max": 29
+							},
+							"text": "Cortina",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.29",
+							"roll": {
+								"min": 30,
+								"max": 30
+							},
+							"text": "Vesna",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.30",
+							"roll": {
+								"min": 31,
+								"max": 31
+							},
+							"text": "Kataka",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.31",
+							"roll": {
+								"min": 32,
+								"max": 32
+							},
+							"text": "Keyshia",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.32",
+							"roll": {
+								"min": 33,
+								"max": 33
+							},
+							"text": "Mila",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.33",
+							"roll": {
+								"min": 34,
+								"max": 34
+							},
+							"text": "Lili",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.34",
+							"roll": {
+								"min": 35,
+								"max": 35
+							},
+							"text": "Vigo",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.35",
+							"roll": {
+								"min": 36,
+								"max": 36
+							},
+							"text": "Sadia",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.36",
+							"roll": {
+								"min": 37,
+								"max": 37
+							},
+							"text": "Malik",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.37",
+							"roll": {
+								"min": 38,
+								"max": 38
+							},
+							"text": "Dag",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.38",
+							"roll": {
+								"min": 39,
+								"max": 39
+							},
+							"text": "Kuno",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.39",
+							"roll": {
+								"min": 40,
+								"max": 40
+							},
+							"text": "Reva",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.40",
+							"roll": {
+								"min": 41,
+								"max": 41
+							},
+							"text": "Kai",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.41",
+							"roll": {
+								"min": 42,
+								"max": 42
+							},
+							"text": "Kalina",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.42",
+							"roll": {
+								"min": 43,
+								"max": 43
+							},
+							"text": "Jihan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.43",
+							"roll": {
+								"min": 44,
+								"max": 44
+							},
+							"text": "Hennion",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.44",
+							"roll": {
+								"min": 45,
+								"max": 45
+							},
+							"text": "Abram",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.45",
+							"roll": {
+								"min": 46,
+								"max": 46
+							},
+							"text": "Aida",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.46",
+							"roll": {
+								"min": 47,
+								"max": 47
+							},
+							"text": "Myrtle",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.47",
+							"roll": {
+								"min": 48,
+								"max": 48
+							},
+							"text": "Nekun",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.48",
+							"roll": {
+								"min": 49,
+								"max": 49
+							},
+							"text": "Menna",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.49",
+							"roll": {
+								"min": 50,
+								"max": 50
+							},
+							"text": "Tahir",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.50",
+							"roll": {
+								"min": 51,
+								"max": 51
+							},
+							"text": "Sarria",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.51",
+							"roll": {
+								"min": 52,
+								"max": 52
+							},
+							"text": "Nakura",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.52",
+							"roll": {
+								"min": 53,
+								"max": 53
+							},
+							"text": "Akiya",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.53",
+							"roll": {
+								"min": 54,
+								"max": 54
+							},
+							"text": "Talan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.54",
+							"roll": {
+								"min": 55,
+								"max": 55
+							},
+							"text": "Mattick",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.55",
+							"roll": {
+								"min": 56,
+								"max": 56
+							},
+							"text": "Okoth",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.56",
+							"roll": {
+								"min": 57,
+								"max": 57
+							},
+							"text": "Khulan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.57",
+							"roll": {
+								"min": 58,
+								"max": 58
+							},
+							"text": "Verena",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.58",
+							"roll": {
+								"min": 59,
+								"max": 59
+							},
+							"text": "Beltran",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.59",
+							"roll": {
+								"min": 60,
+								"max": 60
+							},
+							"text": "Del",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.60",
+							"roll": {
+								"min": 61,
+								"max": 61
+							},
+							"text": "Ranna",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.61",
+							"roll": {
+								"min": 62,
+								"max": 62
+							},
+							"text": "Alina",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.62",
+							"roll": {
+								"min": 63,
+								"max": 63
+							},
+							"text": "Muna",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.63",
+							"roll": {
+								"min": 64,
+								"max": 64
+							},
+							"text": "Mura",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.64",
+							"roll": {
+								"min": 65,
+								"max": 65
+							},
+							"text": "Torrens",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.65",
+							"roll": {
+								"min": 66,
+								"max": 66
+							},
+							"text": "Yuda",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.66",
+							"roll": {
+								"min": 67,
+								"max": 67
+							},
+							"text": "Nazmi",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.67",
+							"roll": {
+								"min": 68,
+								"max": 68
+							},
+							"text": "Ghalen",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.68",
+							"roll": {
+								"min": 69,
+								"max": 69
+							},
+							"text": "Sarda",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.69",
+							"roll": {
+								"min": 70,
+								"max": 70
+							},
+							"text": "Shona",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.70",
+							"roll": {
+								"min": 71,
+								"max": 71
+							},
+							"text": "Kalidas",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.71",
+							"roll": {
+								"min": 72,
+								"max": 72
+							},
+							"text": "Wena",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.72",
+							"roll": {
+								"min": 73,
+								"max": 73
+							},
+							"text": "Sendra",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.73",
+							"roll": {
+								"min": 74,
+								"max": 74
+							},
+							"text": "Kori",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.74",
+							"roll": {
+								"min": 75,
+								"max": 75
+							},
+							"text": "Setara",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.75",
+							"roll": {
+								"min": 76,
+								"max": 76
+							},
+							"text": "Lucia",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.76",
+							"roll": {
+								"min": 77,
+								"max": 77
+							},
+							"text": "Maya",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.77",
+							"roll": {
+								"min": 78,
+								"max": 78
+							},
+							"text": "Reema",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.78",
+							"roll": {
+								"min": 79,
+								"max": 79
+							},
+							"text": "Yorath",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.79",
+							"roll": {
+								"min": 80,
+								"max": 80
+							},
+							"text": "Rhoddri",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.80",
+							"roll": {
+								"min": 81,
+								"max": 81
+							},
+							"text": "Shekhar",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.81",
+							"roll": {
+								"min": 82,
+								"max": 82
+							},
+							"text": "Servan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.82",
+							"roll": {
+								"min": 83,
+								"max": 83
+							},
+							"text": "Reese",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.83",
+							"roll": {
+								"min": 84,
+								"max": 84
+							},
+							"text": "Kenrick",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.84",
+							"roll": {
+								"min": 85,
+								"max": 85
+							},
+							"text": "Indirra",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.85",
+							"roll": {
+								"min": 86,
+								"max": 86
+							},
+							"text": "Giliana",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.86",
+							"roll": {
+								"min": 87,
+								"max": 87
+							},
+							"text": "Jebran",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.87",
+							"roll": {
+								"min": 88,
+								"max": 88
+							},
+							"text": "Kotama",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.88",
+							"roll": {
+								"min": 89,
+								"max": 89
+							},
+							"text": "Fara",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.89",
+							"roll": {
+								"min": 90,
+								"max": 90
+							},
+							"text": "Katrin",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.90",
+							"roll": {
+								"min": 91,
+								"max": 91
+							},
+							"text": "Namba",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.91",
+							"roll": {
+								"min": 92,
+								"max": 92
+							},
+							"text": "Lona",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.92",
+							"roll": {
+								"min": 93,
+								"max": 93
+							},
+							"text": "Taylah",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.93",
+							"roll": {
+								"min": 94,
+								"max": 94
+							},
+							"text": "Kato",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.94",
+							"roll": {
+								"min": 95,
+								"max": 95
+							},
+							"text": "Esra",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.95",
+							"roll": {
+								"min": 96,
+								"max": 96
+							},
+							"text": "Eleri",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.96",
+							"roll": {
+								"min": 97,
+								"max": 97
+							},
+							"text": "Irsia",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.97",
+							"roll": {
+								"min": 98,
+								"max": 98
+							},
+							"text": "Kayu",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.98",
+							"roll": {
+								"min": 99,
+								"max": 99
+							},
+							"text": "Bevan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/name/ironlander_set_2.99",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Chandra",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "proper_noun"
+								}
+							}
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 74,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {
+				"firstborn": {
+					"_id": "oracle_collection:lodestar/name/firstborn",
+					"type": "oracle_collection",
+					"name": "Firstborn Names",
+					"oracle_type": "table_shared_rolls",
+					"summary": "Use these names for elves, giants, varou, and trolls.",
+					"contents": {
+						"elf_1": {
+							"_id": "oracle_rollable:lodestar/name/firstborn/elf_1",
+							"type": "oracle_rollable",
+							"name": "Elf (Set 1)",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Arsula",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Naidita",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Belesunna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Vidarna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Ninsunu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Balathu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Dorosi",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Gezera",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Zursan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Seleeku",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.10",
+									"roll": {
+										"min": 41,
+										"max": 44
+									},
+									"text": "Utamara",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.11",
+									"roll": {
+										"min": 45,
+										"max": 48
+									},
+									"text": "Nebakay",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.12",
+									"roll": {
+										"min": 49,
+										"max": 52
+									},
+									"text": "Dismashk",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.13",
+									"roll": {
+										"min": 53,
+										"max": 56
+									},
+									"text": "Mitunu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.14",
+									"roll": {
+										"min": 57,
+										"max": 60
+									},
+									"text": "Atani",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.15",
+									"roll": {
+										"min": 61,
+										"max": 64
+									},
+									"text": "Kinzura",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.16",
+									"roll": {
+										"min": 65,
+										"max": 68
+									},
+									"text": "Sumula",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.17",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Ukames",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.18",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Ahmeshki",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.19",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Ilsit",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.20",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Mayatanay",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.21",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Etana",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.22",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Gamanna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.23",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Nessana",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_1.24",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Uralar",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								}
+							]
+						},
+						"elf_2": {
+							"_id": "oracle_rollable:lodestar/name/firstborn/elf_2",
+							"type": "oracle_rollable",
+							"name": "Elf (Set 2)",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Tishetu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Leucia",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Sutahe",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Dotani",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Uktannu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Retenay",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Kendalanu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Tahuta",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Mattissa",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Anatu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.10",
+									"roll": {
+										"min": 41,
+										"max": 44
+									},
+									"text": "Aralu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.11",
+									"roll": {
+										"min": 45,
+										"max": 48
+									},
+									"text": "Arakhi",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.12",
+									"roll": {
+										"min": 49,
+										"max": 52
+									},
+									"text": "Ibrahem",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.13",
+									"roll": {
+										"min": 53,
+										"max": 56
+									},
+									"text": "Sinosu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.14",
+									"roll": {
+										"min": 57,
+										"max": 60
+									},
+									"text": "Jemshida",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.15",
+									"roll": {
+										"min": 61,
+										"max": 64
+									},
+									"text": "Visapni",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.16",
+									"roll": {
+										"min": 65,
+										"max": 68
+									},
+									"text": "Hullata",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.17",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Sidura",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.18",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Kerihu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.19",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Ereshki",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.20",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Cybela",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.21",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Anunna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.22",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Otani",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.23",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Ditani",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/elf_2.24",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Faraza",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								}
+							]
+						},
+						"giant": {
+							"_id": "oracle_rollable:lodestar/name/firstborn/giant",
+							"type": "oracle_rollable",
+							"name": "Giant",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Chony",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Banda",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Jochu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Kira",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Khatir",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Chaidu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Atan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Buandu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Javyn",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Khashin",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.10",
+									"roll": {
+										"min": 41,
+										"max": 44
+									},
+									"text": "Bayara",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.11",
+									"roll": {
+										"min": 45,
+										"max": 48
+									},
+									"text": "Temura",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.12",
+									"roll": {
+										"min": 49,
+										"max": 52
+									},
+									"text": "Kidha",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.13",
+									"roll": {
+										"min": 53,
+										"max": 56
+									},
+									"text": "Kathos",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.14",
+									"roll": {
+										"min": 57,
+										"max": 60
+									},
+									"text": "Tanua",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.15",
+									"roll": {
+										"min": 61,
+										"max": 64
+									},
+									"text": "Bashtu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.16",
+									"roll": {
+										"min": 65,
+										"max": 68
+									},
+									"text": "Jaran",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.17",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Othos",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.18",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Khutan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.19",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Otaan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.20",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Martu",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.21",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Baku",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.22",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Tuban",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.23",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Qudan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/giant.24",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Denua",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								}
+							]
+						},
+						"varou": {
+							"_id": "oracle_rollable:lodestar/name/firstborn/varou",
+							"type": "oracle_rollable",
+							"name": "Varou",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Vata",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Zora",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Jasna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Charna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Tana",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Soveen",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Radka",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Zlata",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Leesla",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Byna",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.10",
+									"roll": {
+										"min": 41,
+										"max": 44
+									},
+									"text": "Meeka",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.11",
+									"roll": {
+										"min": 45,
+										"max": 48
+									},
+									"text": "Iskra",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.12",
+									"roll": {
+										"min": 49,
+										"max": 52
+									},
+									"text": "Jarek",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.13",
+									"roll": {
+										"min": 53,
+										"max": 56
+									},
+									"text": "Darva",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.14",
+									"roll": {
+										"min": 57,
+										"max": 60
+									},
+									"text": "Neda",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.15",
+									"roll": {
+										"min": 61,
+										"max": 64
+									},
+									"text": "Keha",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.16",
+									"roll": {
+										"min": 65,
+										"max": 68
+									},
+									"text": "Zhivka",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.17",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Kvata",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.18",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Staysa",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.19",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Evka",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.20",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Vuksha",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.21",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Muko",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.22",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Dreko",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.23",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Aleko",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/varou.24",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Vojan",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								}
+							]
+						},
+						"troll": {
+							"_id": "oracle_rollable:lodestar/name/firstborn/troll",
+							"type": "oracle_rollable",
+							"name": "Troll",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Rattle",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Scratch",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Wallow",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Groak",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Gimble",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Scar",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Cratch",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Creech",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Shush",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Glush",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.10",
+									"roll": {
+										"min": 41,
+										"max": 44
+									},
+									"text": "Slar",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.11",
+									"roll": {
+										"min": 45,
+										"max": 48
+									},
+									"text": "Gnash",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.12",
+									"roll": {
+										"min": 49,
+										"max": 52
+									},
+									"text": "Stoad",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.13",
+									"roll": {
+										"min": 53,
+										"max": 56
+									},
+									"text": "Grig",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.14",
+									"roll": {
+										"min": 57,
+										"max": 60
+									},
+									"text": "Bleat",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.15",
+									"roll": {
+										"min": 61,
+										"max": 64
+									},
+									"text": "Chortle",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.16",
+									"roll": {
+										"min": 65,
+										"max": 68
+									},
+									"text": "Cluck",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.17",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Slith",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.18",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Mongo",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.19",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Creak",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.20",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Burble",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.21",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Vrusk",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.22",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Snuffle",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.23",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Leech",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/name/firstborn/troll.24",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Herk",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "proper_noun"
+										}
+									}
+								}
+							]
+						}
+					},
+					"column_labels": {
+						"roll": "Roll"
+					},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 75,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 73,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"combat": {
+			"_id": "oracle_collection:lodestar/combat",
+			"type": "oracle_collection",
+			"name": "Combat Oracles",
+			"oracle_type": "tables",
+			"contents": {
+				"battleground": {
+					"_id": "oracle_rollable:lodestar/combat/battleground",
+					"type": "oracle_rollable",
+					"name": "Battleground",
+					"oracle_type": "table_text2",
+					"dice": "1d100",
+					"summary": "Roll on this oracle to reveal a feature of the combat environment that affects the fight. Use the result to inspire tactical choices or complicate the situation.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result",
+						"text2": "Details"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.0",
+							"roll": {
+								"min": 1,
+								"max": 5
+							},
+							"text": "Slippery surface",
+							"text2": "Mud, ice, rain-slick rocks"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.1",
+							"roll": {
+								"min": 6,
+								"max": 10
+							},
+							"text": "Encumbering terrain",
+							"text2": "Water, muck, deep snow, webs"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.2",
+							"roll": {
+								"min": 11,
+								"max": 15
+							},
+							"text": "Precipitous drop",
+							"text2": "Cliff, ravine, pit, stairs"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.3",
+							"roll": {
+								"min": 16,
+								"max": 20
+							},
+							"text": "Obstructed path",
+							"text2": "Barricade, toppled ruin, fallen tree"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.4",
+							"roll": {
+								"min": 21,
+								"max": 25
+							},
+							"text": "High ground",
+							"text2": "Mound, outcropping, climbable structure"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.5",
+							"roll": {
+								"min": 26,
+								"max": 30
+							},
+							"text": "Cluttered terrain",
+							"text2": "Rubble, rocks, roots"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.6",
+							"roll": {
+								"min": 31,
+								"max": 35
+							},
+							"text": "Low visibility",
+							"text2": "Darkness, smoke, mist, torrential rain"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.7",
+							"roll": {
+								"min": 36,
+								"max": 40
+							},
+							"text": "Impassable border",
+							"text2": "Deep waterway, high wall, cliff face, locked door"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.8",
+							"roll": {
+								"min": 41,
+								"max": 45
+							},
+							"text": "Scattered cover",
+							"text2": "Low walls, boulders, trees, crates"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.9",
+							"roll": {
+								"min": 46,
+								"max": 50
+							},
+							"text": "Cramped spaces",
+							"text2": "Narrow tunnel, crowded room, dense woods"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.10",
+							"roll": {
+								"min": 51,
+								"max": 55
+							},
+							"text": "Treacherous ground",
+							"text2": "Fire pit, boiling hot spring, quagmire"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.11",
+							"roll": {
+								"min": 56,
+								"max": 60
+							},
+							"text": "Restricted approach",
+							"text2": "Bridge, corridor, river ford, narrow canyon"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.12",
+							"roll": {
+								"min": 61,
+								"max": 65
+							},
+							"text": "Collapsing foundation",
+							"text2": "Crumbling ruins, thin ice, undermined earth"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.13",
+							"roll": {
+								"min": 66,
+								"max": 70
+							},
+							"text": "Bounded space",
+							"text2": "Dueling circle, woodland clearing, standing stones"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.14",
+							"roll": {
+								"min": 71,
+								"max": 75
+							},
+							"text": "Pitched ground",
+							"text2": "Steep hillside, rooftop, collapsed ruin, ship deck"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.15",
+							"roll": {
+								"min": 76,
+								"max": 80
+							},
+							"text": "Hidden hazard",
+							"text2": "Trap, sinkhole, lurking creature, waiting ambushers"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.16",
+							"roll": {
+								"min": 81,
+								"max": 85
+							},
+							"text": "Frenzied distractions",
+							"text2": "Noncombatants, panicked creatures, insect swarms"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.17",
+							"roll": {
+								"min": 86,
+								"max": 90
+							},
+							"text": "Destructive chaos",
+							"text2": "Storm, fire, flooding, rampaging creature"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.18",
+							"roll": {
+								"min": 91,
+								"max": 95
+							},
+							"text": "Unnatural forces",
+							"text2": "Mystic energies, runic symbols, sorcerous artifacts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/battleground.19",
+							"roll": {
+								"min": 96,
+								"max": 100
+							},
+							"text": "Cursed ground",
+							"text2": "Corpses, shambling undead, ghostly specters"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 94,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"tactic": {
+					"_id": "oracle_rollable:lodestar/combat/tactic",
+					"type": "oracle_rollable",
+					"name": "Tactic",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to help inspire an action for an NPC in combat. When you're not sure what your foe does next, particularly when they have initiative, roll on this table and interpret the result as appropriate to the situation.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.0",
+							"roll": {
+								"min": 1,
+								"max": 3
+							},
+							"text": "Compel a surrender."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.1",
+							"roll": {
+								"min": 4,
+								"max": 6
+							},
+							"text": "Coordinate with allies."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.2",
+							"roll": {
+								"min": 7,
+								"max": 9
+							},
+							"text": "Gather reinforcements."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.3",
+							"roll": {
+								"min": 10,
+								"max": 13
+							},
+							"text": "Seize something or someone."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.4",
+							"roll": {
+								"min": 14,
+								"max": 17
+							},
+							"text": "Provoke a reckless response."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.5",
+							"roll": {
+								"min": 18,
+								"max": 21
+							},
+							"text": "Intimidate or frighten."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.6",
+							"roll": {
+								"min": 22,
+								"max": 25
+							},
+							"text": "Reveal a surprising truth."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.7",
+							"roll": {
+								"min": 26,
+								"max": 29
+							},
+							"text": "Shift focus to something else."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.8",
+							"roll": {
+								"min": 30,
+								"max": 33
+							},
+							"text": "Destroy or damage something."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.9",
+							"roll": {
+								"min": 34,
+								"max": 39
+							},
+							"text": "Take a decisive action."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.10",
+							"roll": {
+								"min": 40,
+								"max": 45
+							},
+							"text": "Reinforce defenses."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.11",
+							"roll": {
+								"min": 46,
+								"max": 52
+							},
+							"text": "Ready an action."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.12",
+							"roll": {
+								"min": 53,
+								"max": 60
+							},
+							"text": "Use the terrain to gain advantage."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.13",
+							"roll": {
+								"min": 61,
+								"max": 68
+							},
+							"text": "Take advantage of an opening."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.14",
+							"roll": {
+								"min": 69,
+								"max": 78
+							},
+							"text": "Create an opportunity."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.15",
+							"roll": {
+								"min": 79,
+								"max": 89
+							},
+							"text": "Attack with precision."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.16",
+							"roll": {
+								"min": 90,
+								"max": 99
+							},
+							"text": "Attack with power."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/combat/tactic.17",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Take an unexpected action."
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 95,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 94,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"core": {
+			"_id": "oracle_collection:lodestar/core",
+			"type": "oracle_collection",
+			"name": "Core Oracles",
+			"oracle_type": "tables",
+			"contents": {
+				"descriptor": {
+					"_id": "oracle_rollable:lodestar/core/descriptor",
+					"type": "oracle_rollable",
+					"name": "Descriptor",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use the Descriptor oracle to add texture to the details of a location or event. Combined with a Focus oracle result, it provides a more specific prompt than either oracle alone.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.0",
+							"roll": {
+								"min": 1,
+								"max": 1
+							},
+							"text": "Small",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.1",
+							"roll": {
+								"min": 2,
+								"max": 2
+							},
+							"text": "Collapsed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.2",
+							"roll": {
+								"min": 3,
+								"max": 3
+							},
+							"text": "Protected",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.3",
+							"roll": {
+								"min": 4,
+								"max": 4
+							},
+							"text": "Infested",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.4",
+							"roll": {
+								"min": 5,
+								"max": 5
+							},
+							"text": "Misty",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.5",
+							"roll": {
+								"min": 6,
+								"max": 6
+							},
+							"text": "Towering",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.6",
+							"roll": {
+								"min": 7,
+								"max": 7
+							},
+							"text": "Light",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.7",
+							"roll": {
+								"min": 8,
+								"max": 8
+							},
+							"text": "Marked",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.8",
+							"roll": {
+								"min": 9,
+								"max": 9
+							},
+							"text": "Crafted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.9",
+							"roll": {
+								"min": 10,
+								"max": 10
+							},
+							"text": "Remote",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.10",
+							"roll": {
+								"min": 11,
+								"max": 11
+							},
+							"text": "Deep",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.11",
+							"roll": {
+								"min": 12,
+								"max": 12
+							},
+							"text": "Captured",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.12",
+							"roll": {
+								"min": 13,
+								"max": 13
+							},
+							"text": "Ruined",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.13",
+							"roll": {
+								"min": 14,
+								"max": 14
+							},
+							"text": "Safe",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.14",
+							"roll": {
+								"min": 15,
+								"max": 15
+							},
+							"text": "Precious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.15",
+							"roll": {
+								"min": 16,
+								"max": 16
+							},
+							"text": "Abandoned",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.16",
+							"roll": {
+								"min": 17,
+								"max": 17
+							},
+							"text": "Inaccessible",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.17",
+							"roll": {
+								"min": 18,
+								"max": 18
+							},
+							"text": "Barren",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.18",
+							"roll": {
+								"min": 19,
+								"max": 19
+							},
+							"text": "Guarded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.19",
+							"roll": {
+								"min": 20,
+								"max": 20
+							},
+							"text": "Impassable",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.20",
+							"roll": {
+								"min": 21,
+								"max": 21
+							},
+							"text": "Corrupted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.21",
+							"roll": {
+								"min": 22,
+								"max": 22
+							},
+							"text": "Foreboding",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.22",
+							"roll": {
+								"min": 23,
+								"max": 23
+							},
+							"text": "Wild",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.23",
+							"roll": {
+								"min": 24,
+								"max": 24
+							},
+							"text": "Fragile",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.24",
+							"roll": {
+								"min": 25,
+								"max": 25
+							},
+							"text": "Isolated",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.25",
+							"roll": {
+								"min": 26,
+								"max": 26
+							},
+							"text": "Inhabited",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.26",
+							"roll": {
+								"min": 27,
+								"max": 27
+							},
+							"text": "Defended",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.27",
+							"roll": {
+								"min": 28,
+								"max": 28
+							},
+							"text": "Active",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.28",
+							"roll": {
+								"min": 29,
+								"max": 29
+							},
+							"text": "Bloody",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.29",
+							"roll": {
+								"min": 30,
+								"max": 30
+							},
+							"text": "Dying",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.30",
+							"roll": {
+								"min": 31,
+								"max": 31
+							},
+							"text": "Grim",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.31",
+							"roll": {
+								"min": 32,
+								"max": 32
+							},
+							"text": "Shrouded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.32",
+							"roll": {
+								"min": 33,
+								"max": 33
+							},
+							"text": "Dead",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.33",
+							"roll": {
+								"min": 34,
+								"max": 34
+							},
+							"text": "Sealed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.34",
+							"roll": {
+								"min": 35,
+								"max": 35
+							},
+							"text": "Flooded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.35",
+							"roll": {
+								"min": 36,
+								"max": 36
+							},
+							"text": "Withered",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.36",
+							"roll": {
+								"min": 37,
+								"max": 37
+							},
+							"text": "Lush",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.37",
+							"roll": {
+								"min": 38,
+								"max": 38
+							},
+							"text": "Fortified",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.38",
+							"roll": {
+								"min": 39,
+								"max": 39
+							},
+							"text": "Beautiful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.39",
+							"roll": {
+								"min": 40,
+								"max": 40
+							},
+							"text": "Blocked",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.40",
+							"roll": {
+								"min": 41,
+								"max": 41
+							},
+							"text": "Desolate",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.41",
+							"roll": {
+								"min": 42,
+								"max": 42
+							},
+							"text": "Deadly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.42",
+							"roll": {
+								"min": 43,
+								"max": 43
+							},
+							"text": "Massive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.43",
+							"roll": {
+								"min": 44,
+								"max": 44
+							},
+							"text": "Hallowed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.44",
+							"roll": {
+								"min": 45,
+								"max": 45
+							},
+							"text": "Confined",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.45",
+							"roll": {
+								"min": 46,
+								"max": 46
+							},
+							"text": "Unusual",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.46",
+							"roll": {
+								"min": 47,
+								"max": 47
+							},
+							"text": "Mysterious",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.47",
+							"roll": {
+								"min": 48,
+								"max": 48
+							},
+							"text": "Strange",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.48",
+							"roll": {
+								"min": 49,
+								"max": 49
+							},
+							"text": "Depleted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.49",
+							"roll": {
+								"min": 50,
+								"max": 50
+							},
+							"text": "Crowded",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.50",
+							"roll": {
+								"min": 51,
+								"max": 51
+							},
+							"text": "Fertile",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.51",
+							"roll": {
+								"min": 52,
+								"max": 52
+							},
+							"text": "Diverse",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.52",
+							"roll": {
+								"min": 53,
+								"max": 53
+							},
+							"text": "Sheltered",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.53",
+							"roll": {
+								"min": 54,
+								"max": 54
+							},
+							"text": "Destroyed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.54",
+							"roll": {
+								"min": 55,
+								"max": 55
+							},
+							"text": "Open",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.55",
+							"roll": {
+								"min": 56,
+								"max": 56
+							},
+							"text": "Exposed",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.56",
+							"roll": {
+								"min": 57,
+								"max": 57
+							},
+							"text": "Contested",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.57",
+							"roll": {
+								"min": 58,
+								"max": 58
+							},
+							"text": "Blighted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.58",
+							"roll": {
+								"min": 59,
+								"max": 59
+							},
+							"text": "Rugged",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.59",
+							"roll": {
+								"min": 60,
+								"max": 60
+							},
+							"text": "Unnatural",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.60",
+							"roll": {
+								"min": 61,
+								"max": 61
+							},
+							"text": "Secret",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.61",
+							"roll": {
+								"min": 62,
+								"max": 62
+							},
+							"text": "Dark",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.62",
+							"roll": {
+								"min": 63,
+								"max": 63
+							},
+							"text": "Sunken",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.63",
+							"roll": {
+								"min": 64,
+								"max": 64
+							},
+							"text": "Abundant",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.64",
+							"roll": {
+								"min": 65,
+								"max": 65
+							},
+							"text": "Raided",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.65",
+							"roll": {
+								"min": 66,
+								"max": 66
+							},
+							"text": "Suspended",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.66",
+							"roll": {
+								"min": 67,
+								"max": 67
+							},
+							"text": "Hostile",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.67",
+							"roll": {
+								"min": 68,
+								"max": 68
+							},
+							"text": "Empty",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.68",
+							"roll": {
+								"min": 69,
+								"max": 69
+							},
+							"text": "Overgrown",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.69",
+							"roll": {
+								"min": 70,
+								"max": 70
+							},
+							"text": "Chaotic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.70",
+							"roll": {
+								"min": 71,
+								"max": 71
+							},
+							"text": "Peaceful",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.71",
+							"roll": {
+								"min": 72,
+								"max": 72
+							},
+							"text": "Broken",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.72",
+							"roll": {
+								"min": 73,
+								"max": 73
+							},
+							"text": "Ensnaring",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.73",
+							"roll": {
+								"min": 74,
+								"max": 74
+							},
+							"text": "Frozen",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.74",
+							"roll": {
+								"min": 75,
+								"max": 75
+							},
+							"text": "Ravaged",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.75",
+							"roll": {
+								"min": 76,
+								"max": 76
+							},
+							"text": "Expansive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.76",
+							"roll": {
+								"min": 77,
+								"max": 77
+							},
+							"text": "Toxic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.77",
+							"roll": {
+								"min": 78,
+								"max": 78
+							},
+							"text": "High",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.78",
+							"roll": {
+								"min": 79,
+								"max": 79
+							},
+							"text": "Sacred",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.79",
+							"roll": {
+								"min": 80,
+								"max": 80
+							},
+							"text": "Low",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.80",
+							"roll": {
+								"min": 81,
+								"max": 81
+							},
+							"text": "Forsaken",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.81",
+							"roll": {
+								"min": 82,
+								"max": 82
+							},
+							"text": "Fallen",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.82",
+							"roll": {
+								"min": 83,
+								"max": 83
+							},
+							"text": "Shadowy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.83",
+							"roll": {
+								"min": 84,
+								"max": 84
+							},
+							"text": "Unstable",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.84",
+							"roll": {
+								"min": 85,
+								"max": 85
+							},
+							"text": "Hidden",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.85",
+							"roll": {
+								"min": 86,
+								"max": 86
+							},
+							"text": "Haunted",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.86",
+							"roll": {
+								"min": 87,
+								"max": 87
+							},
+							"text": "Buried",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.87",
+							"roll": {
+								"min": 88,
+								"max": 88
+							},
+							"text": "Damaged",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.88",
+							"roll": {
+								"min": 89,
+								"max": 89
+							},
+							"text": "Ancient",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.89",
+							"roll": {
+								"min": 90,
+								"max": 90
+							},
+							"text": "Scarred",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.90",
+							"roll": {
+								"min": 91,
+								"max": 91
+							},
+							"text": "Elevated",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.91",
+							"roll": {
+								"min": 92,
+								"max": 92
+							},
+							"text": "Forgotten",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.92",
+							"roll": {
+								"min": 93,
+								"max": 93
+							},
+							"text": "Preserved",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.93",
+							"roll": {
+								"min": 94,
+								"max": 94
+							},
+							"text": "Trapped",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.94",
+							"roll": {
+								"min": 95,
+								"max": 95
+							},
+							"text": "Mystic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.95",
+							"roll": {
+								"min": 96,
+								"max": 96
+							},
+							"text": "Natural",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.96",
+							"roll": {
+								"min": 97,
+								"max": 97
+							},
+							"text": "Treacherous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.97",
+							"roll": {
+								"min": 98,
+								"max": 98
+							},
+							"text": "Watery",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.98",
+							"roll": {
+								"min": 99,
+								"max": 99
+							},
+							"text": "Moving",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/descriptor.99",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Foul",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "adjective"
+								}
+							}
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 52,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"focus": {
+					"_id": "oracle_rollable:lodestar/core/focus",
+					"type": "oracle_rollable",
+					"name": "Focus",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use the Focus oracle to add detail or subject matter to a location or event. Combined with a Descriptor oracle result, it provides a more specific prompt than either oracle alone.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.0",
+							"roll": {
+								"min": 1,
+								"max": 1
+							},
+							"text": "Bridge",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.1",
+							"roll": {
+								"min": 2,
+								"max": 2
+							},
+							"text": "Being",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.2",
+							"roll": {
+								"min": 3,
+								"max": 3
+							},
+							"text": "Archive",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.3",
+							"roll": {
+								"min": 4,
+								"max": 4
+							},
+							"text": "Gap",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.4",
+							"roll": {
+								"min": 5,
+								"max": 5
+							},
+							"text": "Message",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.5",
+							"roll": {
+								"min": 6,
+								"max": 6
+							},
+							"text": "Denizen",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.6",
+							"roll": {
+								"min": 7,
+								"max": 7
+							},
+							"text": "Commodity",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.7",
+							"roll": {
+								"min": 8,
+								"max": 8
+							},
+							"text": "Vegetation",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.8",
+							"roll": {
+								"min": 9,
+								"max": 9
+							},
+							"text": "Rubble",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.9",
+							"roll": {
+								"min": 10,
+								"max": 10
+							},
+							"text": "Rendezvous",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.10",
+							"roll": {
+								"min": 11,
+								"max": 11
+							},
+							"text": "Hideaway",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.11",
+							"roll": {
+								"min": 12,
+								"max": 12
+							},
+							"text": "Vault",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.12",
+							"roll": {
+								"min": 13,
+								"max": 13
+							},
+							"text": "Crossing",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.13",
+							"roll": {
+								"min": 14,
+								"max": 14
+							},
+							"text": "Camp",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.14",
+							"roll": {
+								"min": 15,
+								"max": 15
+							},
+							"text": "Inhabitant",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.15",
+							"roll": {
+								"min": 16,
+								"max": 16
+							},
+							"text": "Landscape",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.16",
+							"roll": {
+								"min": 17,
+								"max": 17
+							},
+							"text": "Boundary",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.17",
+							"roll": {
+								"min": 18,
+								"max": 18
+							},
+							"text": "Entry",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.18",
+							"roll": {
+								"min": 19,
+								"max": 19
+							},
+							"text": "Grave",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.19",
+							"roll": {
+								"min": 20,
+								"max": 20
+							},
+							"text": "Beast",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.20",
+							"roll": {
+								"min": 21,
+								"max": 21
+							},
+							"text": "Construction",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.21",
+							"roll": {
+								"min": 22,
+								"max": 22
+							},
+							"text": "Iron",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.22",
+							"roll": {
+								"min": 23,
+								"max": 23
+							},
+							"text": "Threshold",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.23",
+							"roll": {
+								"min": 24,
+								"max": 24
+							},
+							"text": "Sound",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.24",
+							"roll": {
+								"min": 25,
+								"max": 25
+							},
+							"text": "Debris",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.25",
+							"roll": {
+								"min": 26,
+								"max": 26
+							},
+							"text": "Monument",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.26",
+							"roll": {
+								"min": 27,
+								"max": 27
+							},
+							"text": "Terrain",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.27",
+							"roll": {
+								"min": 28,
+								"max": 28
+							},
+							"text": "Battlefield",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.28",
+							"roll": {
+								"min": 29,
+								"max": 29
+							},
+							"text": "Stone",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.29",
+							"roll": {
+								"min": 30,
+								"max": 30
+							},
+							"text": "Shortcut",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.30",
+							"roll": {
+								"min": 31,
+								"max": 31
+							},
+							"text": "Symbol",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.31",
+							"roll": {
+								"min": 32,
+								"max": 32
+							},
+							"text": "Ambush",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.32",
+							"roll": {
+								"min": 33,
+								"max": 33
+							},
+							"text": "Water",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.33",
+							"roll": {
+								"min": 34,
+								"max": 34
+							},
+							"text": "Viewpoint",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.34",
+							"roll": {
+								"min": 35,
+								"max": 35
+							},
+							"text": "Environment",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.35",
+							"roll": {
+								"min": 36,
+								"max": 36
+							},
+							"text": "Excavation",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.36",
+							"roll": {
+								"min": 37,
+								"max": 37
+							},
+							"text": "Person",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.37",
+							"roll": {
+								"min": 38,
+								"max": 38
+							},
+							"text": "Gathering",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.38",
+							"roll": {
+								"min": 39,
+								"max": 39
+							},
+							"text": "Enclosure",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.39",
+							"roll": {
+								"min": 40,
+								"max": 40
+							},
+							"text": "Ritual",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.40",
+							"roll": {
+								"min": 41,
+								"max": 41
+							},
+							"text": "Weather",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.41",
+							"roll": {
+								"min": 42,
+								"max": 42
+							},
+							"text": "Precipice",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.42",
+							"roll": {
+								"min": 43,
+								"max": 43
+							},
+							"text": "Opening",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.43",
+							"roll": {
+								"min": 44,
+								"max": 44
+							},
+							"text": "Rift",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.44",
+							"roll": {
+								"min": 45,
+								"max": 45
+							},
+							"text": "Bones",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.45",
+							"roll": {
+								"min": 46,
+								"max": 46
+							},
+							"text": "Transport",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.46",
+							"roll": {
+								"min": 47,
+								"max": 47
+							},
+							"text": "Territory",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.47",
+							"roll": {
+								"min": 48,
+								"max": 48
+							},
+							"text": "Clearing",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.48",
+							"roll": {
+								"min": 49,
+								"max": 49
+							},
+							"text": "Hole",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.49",
+							"roll": {
+								"min": 50,
+								"max": 50
+							},
+							"text": "Growth",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.50",
+							"roll": {
+								"min": 51,
+								"max": 51
+							},
+							"text": "Portal",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.51",
+							"roll": {
+								"min": 52,
+								"max": 52
+							},
+							"text": "Route",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.52",
+							"roll": {
+								"min": 53,
+								"max": 53
+							},
+							"text": "Hazard",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.53",
+							"roll": {
+								"min": 54,
+								"max": 54
+							},
+							"text": "Habitat",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.54",
+							"roll": {
+								"min": 55,
+								"max": 55
+							},
+							"text": "Trail",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.55",
+							"roll": {
+								"min": 56,
+								"max": 56
+							},
+							"text": "Illusion",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.56",
+							"roll": {
+								"min": 57,
+								"max": 57
+							},
+							"text": "Refuge",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.57",
+							"roll": {
+								"min": 58,
+								"max": 58
+							},
+							"text": "Relic",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.58",
+							"roll": {
+								"min": 59,
+								"max": 59
+							},
+							"text": "Span",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.59",
+							"roll": {
+								"min": 60,
+								"max": 60
+							},
+							"text": "Formation",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.60",
+							"roll": {
+								"min": 61,
+								"max": 61
+							},
+							"text": "Nest",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.61",
+							"roll": {
+								"min": 62,
+								"max": 62
+							},
+							"text": "Treasure",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.62",
+							"roll": {
+								"min": 63,
+								"max": 63
+							},
+							"text": "Prominence",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.63",
+							"roll": {
+								"min": 64,
+								"max": 64
+							},
+							"text": "Predator",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.64",
+							"roll": {
+								"min": 65,
+								"max": 65
+							},
+							"text": "Trap",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.65",
+							"roll": {
+								"min": 66,
+								"max": 66
+							},
+							"text": "People",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.66",
+							"roll": {
+								"min": 67,
+								"max": 67
+							},
+							"text": "Tracks",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.67",
+							"roll": {
+								"min": 68,
+								"max": 68
+							},
+							"text": "Combatant",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.68",
+							"roll": {
+								"min": 69,
+								"max": 69
+							},
+							"text": "Storage",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.69",
+							"roll": {
+								"min": 70,
+								"max": 70
+							},
+							"text": "Riches",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.70",
+							"roll": {
+								"min": 71,
+								"max": 71
+							},
+							"text": "Anomaly",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.71",
+							"roll": {
+								"min": 72,
+								"max": 72
+							},
+							"text": "Outpost",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.72",
+							"roll": {
+								"min": 73,
+								"max": 73
+							},
+							"text": "Settlement",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.73",
+							"roll": {
+								"min": 74,
+								"max": 74
+							},
+							"text": "Cultivation",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.74",
+							"roll": {
+								"min": 75,
+								"max": 75
+							},
+							"text": "Craftwork",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.75",
+							"roll": {
+								"min": 76,
+								"max": 76
+							},
+							"text": "Caravan",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.76",
+							"roll": {
+								"min": 77,
+								"max": 77
+							},
+							"text": "Void",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.77",
+							"roll": {
+								"min": 78,
+								"max": 78
+							},
+							"text": "Fire",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.78",
+							"roll": {
+								"min": 79,
+								"max": 79
+							},
+							"text": "Smell",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.79",
+							"roll": {
+								"min": 80,
+								"max": 80
+							},
+							"text": "Remains",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.80",
+							"roll": {
+								"min": 81,
+								"max": 81
+							},
+							"text": "Artifact",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.81",
+							"roll": {
+								"min": 82,
+								"max": 82
+							},
+							"text": "Energy",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.82",
+							"roll": {
+								"min": 83,
+								"max": 83
+							},
+							"text": "Puzzle",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.83",
+							"roll": {
+								"min": 84,
+								"max": 84
+							},
+							"text": "Equipment",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.84",
+							"roll": {
+								"min": 85,
+								"max": 85
+							},
+							"text": "Discovery",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.85",
+							"roll": {
+								"min": 86,
+								"max": 86
+							},
+							"text": "Apparition",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.86",
+							"roll": {
+								"min": 87,
+								"max": 87
+							},
+							"text": "Remnant",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.87",
+							"roll": {
+								"min": 88,
+								"max": 88
+							},
+							"text": "Guardian",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.88",
+							"roll": {
+								"min": 89,
+								"max": 89
+							},
+							"text": "Shrine",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.89",
+							"roll": {
+								"min": 90,
+								"max": 90
+							},
+							"text": "Barricade",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.90",
+							"roll": {
+								"min": 91,
+								"max": 91
+							},
+							"text": "Insects",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.91",
+							"roll": {
+								"min": 92,
+								"max": 92
+							},
+							"text": "Waterway",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.92",
+							"roll": {
+								"min": 93,
+								"max": 93
+							},
+							"text": "Material",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.93",
+							"roll": {
+								"min": 94,
+								"max": 94
+							},
+							"text": "Worksite",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.94",
+							"roll": {
+								"min": 95,
+								"max": 95
+							},
+							"text": "Mire",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.95",
+							"roll": {
+								"min": 96,
+								"max": 96
+							},
+							"text": "Lair",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.96",
+							"roll": {
+								"min": 97,
+								"max": 97
+							},
+							"text": "Obstacle",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.97",
+							"roll": {
+								"min": 98,
+								"max": 98
+							},
+							"text": "Wood",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.98",
+							"roll": {
+								"min": 99,
+								"max": 99
+							},
+							"text": "Animal",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/core/focus.99",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Corpse",
+							"_i18n": {
+								"text": {
+									"part_of_speech": "common_noun"
+								}
+							}
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 53,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 50,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"location": {
+			"_id": "oracle_collection:lodestar/location",
+			"type": "oracle_collection",
+			"name": "Location Oracles",
+			"oracle_type": "tables",
+			"enhances": [
+				"oracle_collection:classic/place"
+			],
+			"contents": {},
+			"collections": {
+				"overland": {
+					"_id": "oracle_collection:lodestar/location/overland",
+					"type": "oracle_collection",
+					"name": "Overland",
+					"oracle_type": "tables",
+					"contents": {
+						"landmark": {
+							"_id": "oracle_rollable:lodestar/location/overland/landmark",
+							"type": "oracle_rollable",
+							"name": "Landmark",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to help envision a basic feature of the landscape as a journey waypoint or key location.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.0",
+									"roll": {
+										"min": 1,
+										"max": 2
+									},
+									"text": "Ruins",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.1",
+									"roll": {
+										"min": 3,
+										"max": 4
+									},
+									"text": "Wall",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.2",
+									"roll": {
+										"min": 5,
+										"max": 6
+									},
+									"text": "Battlefield",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.3",
+									"roll": {
+										"min": 7,
+										"max": 8
+									},
+									"text": "Hovel",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.4",
+									"roll": {
+										"min": 9,
+										"max": 10
+									},
+									"text": "Springs",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.5",
+									"roll": {
+										"min": 11,
+										"max": 12
+									},
+									"text": "Campsite",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.6",
+									"roll": {
+										"min": 13,
+										"max": 14
+									},
+									"text": "Bridge",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.7",
+									"roll": {
+										"min": 15,
+										"max": 16
+									},
+									"text": "Barrow",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.8",
+									"roll": {
+										"min": 17,
+										"max": 18
+									},
+									"text": "Gravesite",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.9",
+									"roll": {
+										"min": 19,
+										"max": 20
+									},
+									"text": "Waterfall",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.10",
+									"roll": {
+										"min": 21,
+										"max": 22
+									},
+									"text": "Cave",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.11",
+									"roll": {
+										"min": 23,
+										"max": 24
+									},
+									"text": "Swamp",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.12",
+									"roll": {
+										"min": 25,
+										"max": 26
+									},
+									"text": "Road",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.13",
+									"roll": {
+										"min": 27,
+										"max": 28
+									},
+									"text": "Tree",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.14",
+									"roll": {
+										"min": 29,
+										"max": 30
+									},
+									"text": "Pond",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.15",
+									"roll": {
+										"min": 31,
+										"max": 32
+									},
+									"text": "Field",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.16",
+									"roll": {
+										"min": 33,
+										"max": 34
+									},
+									"text": "Marsh",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.17",
+									"roll": {
+										"min": 35,
+										"max": 37
+									},
+									"text": "Settlement",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.18",
+									"roll": {
+										"min": 38,
+										"max": 39
+									},
+									"text": "Rapids",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.19",
+									"roll": {
+										"min": 40,
+										"max": 41
+									},
+									"text": "Pass",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.20",
+									"roll": {
+										"min": 42,
+										"max": 43
+									},
+									"text": "Trail",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.21",
+									"roll": {
+										"min": 44,
+										"max": 45
+									},
+									"text": "Ridge",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.22",
+									"roll": {
+										"min": 46,
+										"max": 47
+									},
+									"text": "Cliff",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.23",
+									"roll": {
+										"min": 48,
+										"max": 49
+									},
+									"text": "Grove",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.24",
+									"roll": {
+										"min": 50,
+										"max": 51
+									},
+									"text": "Moor",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.25",
+									"roll": {
+										"min": 52,
+										"max": 53
+									},
+									"text": "Thicket",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.26",
+									"roll": {
+										"min": 54,
+										"max": 55
+									},
+									"text": "River ford",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.27",
+									"roll": {
+										"min": 56,
+										"max": 57
+									},
+									"text": "Valley",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.28",
+									"roll": {
+										"min": 58,
+										"max": 59
+									},
+									"text": "Fjord / Ravine",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.29",
+									"roll": {
+										"min": 60,
+										"max": 61
+									},
+									"text": "Foothills",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.30",
+									"roll": {
+										"min": 62,
+										"max": 63
+									},
+									"text": "Lake",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.31",
+									"roll": {
+										"min": 64,
+										"max": 66
+									},
+									"text": "River",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.32",
+									"roll": {
+										"min": 67,
+										"max": 68
+									},
+									"text": "Forest",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.33",
+									"roll": {
+										"min": 69,
+										"max": 70
+									},
+									"text": "Hill",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.34",
+									"roll": {
+										"min": 71,
+										"max": 72
+									},
+									"text": "Peak",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.35",
+									"roll": {
+										"min": 73,
+										"max": 75
+									},
+									"text": "Woods",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.36",
+									"roll": {
+										"min": 76,
+										"max": 78
+									},
+									"text": "Stream",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.37",
+									"roll": {
+										"min": 79,
+										"max": 80
+									},
+									"text": "Clearing",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.38",
+									"roll": {
+										"min": 81,
+										"max": 82
+									},
+									"text": "Mine",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.39",
+									"roll": {
+										"min": 83,
+										"max": 84
+									},
+									"text": "Ritual site",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.40",
+									"roll": {
+										"min": 85,
+										"max": 86
+									},
+									"text": "Monument",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.41",
+									"roll": {
+										"min": 87,
+										"max": 88
+									},
+									"text": "Standing stones",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.42",
+									"roll": {
+										"min": 89,
+										"max": 90
+									},
+									"text": "Watchtower",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.43",
+									"roll": {
+										"min": 91,
+										"max": 92
+									},
+									"text": "Sinkhole",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.44",
+									"roll": {
+										"min": 93,
+										"max": 94
+									},
+									"text": "Crater",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.45",
+									"roll": {
+										"min": 95,
+										"max": 96
+									},
+									"text": "Shrine",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.46",
+									"roll": {
+										"min": 97,
+										"max": 98
+									},
+									"text": "Crag",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/landmark.47",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "Anomaly",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 54,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"waypoint": {
+							"_id": "oracle_rollable:lodestar/location/overland/waypoint",
+							"type": "oracle_rollable",
+							"name": "Waypoint",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal a location, discovery, or event when you Undertake a Journey and reach a waypoint.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.0",
+									"roll": {
+										"min": 1,
+										"max": 1
+									},
+									"text": "A camp or settlement comes into view"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.1",
+									"roll": {
+										"min": 2,
+										"max": 2
+									},
+									"text": "A long-dead corpse or skeleton lies here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.2",
+									"roll": {
+										"min": 3,
+										"max": 3
+									},
+									"text": "A herd of wildlife cuts across your path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.3",
+									"roll": {
+										"min": 4,
+										"max": 4
+									},
+									"text": "A wide river winds across the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.4",
+									"roll": {
+										"min": 5,
+										"max": 5
+									},
+									"text": "Flies swarm around an enormous pile of scat"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.5",
+									"roll": {
+										"min": 6,
+										"max": 6
+									},
+									"text": "A stone wall marks an old boundary line"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.6",
+									"roll": {
+										"min": 7,
+										"max": 7
+									},
+									"text": "A cold fire pit hints at the passage of another traveler"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.7",
+									"roll": {
+										"min": 8,
+										"max": 8
+									},
+									"text": "An unsettling silence falls over this area"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.8",
+									"roll": {
+										"min": 9,
+										"max": 9
+									},
+									"text": "You discover the remnants of a ritual"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.9",
+									"roll": {
+										"min": 10,
+										"max": 10
+									},
+									"text": "A crude wall or barricade marks a makeshift fortification"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.10",
+									"roll": {
+										"min": 11,
+										"max": 11
+									},
+									"text": "You cross paths with a lone traveler"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.11",
+									"roll": {
+										"min": 12,
+										"max": 12
+									},
+									"text": "Ash surrounds a long-cold funeral pyre"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.12",
+									"roll": {
+										"min": 13,
+										"max": 13
+									},
+									"text": "A creature stands in defense of its nest or young"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.13",
+									"roll": {
+										"min": 14,
+										"max": 14
+									},
+									"text": "Trinkets and offerings hang from a tree or monument"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.14",
+									"roll": {
+										"min": 15,
+										"max": 15
+									},
+									"text": "A stone-framed doorway marks the entrance to a barrow mound"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.15",
+									"roll": {
+										"min": 16,
+										"max": 16
+									},
+									"text": "Tracks show that others have passed this way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.16",
+									"roll": {
+										"min": 17,
+										"max": 17
+									},
+									"text": "You catch a gleam of metal in the distance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.17",
+									"roll": {
+										"min": 18,
+										"max": 18
+									},
+									"text": "A waterway cuts through the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.18",
+									"roll": {
+										"min": 19,
+										"max": 19
+									},
+									"text": "A ford or ferry marks a river crossing"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.19",
+									"roll": {
+										"min": 20,
+										"max": 20
+									},
+									"text": "You encounter a procession of refugees or nomads"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.20",
+									"roll": {
+										"min": 21,
+										"max": 21
+									},
+									"text": "A grim marker denotes a territorial boundary"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.21",
+									"roll": {
+										"min": 22,
+										"max": 22
+									},
+									"text": "A former worksite lies abandoned"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.22",
+									"roll": {
+										"min": 23,
+										"max": 23
+									},
+									"text": "You hear the footfalls or stirrings of a large creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.23",
+									"roll": {
+										"min": 24,
+										"max": 24
+									},
+									"text": "Something about this place evokes an unnerving sensation"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.24",
+									"roll": {
+										"min": 25,
+										"max": 25
+									},
+									"text": "An abandoned or lifeless settlement lingers in silence"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.25",
+									"roll": {
+										"min": 26,
+										"max": 26
+									},
+									"text": "The temperature shifts unnaturally"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.26",
+									"roll": {
+										"min": 27,
+										"max": 27
+									},
+									"text": "A storm brews on the horizon"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.27",
+									"roll": {
+										"min": 28,
+										"max": 28
+									},
+									"text": "A lake, pond, or pool reflects its surroundings"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.28",
+									"roll": {
+										"min": 29,
+										"max": 29
+									},
+									"text": "This place gives you the discomforting feeling that you are being watched"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.29",
+									"roll": {
+										"min": 30,
+										"max": 30
+									},
+									"text": "A rope bridge sways in the wind"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.30",
+									"roll": {
+										"min": 31,
+										"max": 31
+									},
+									"text": "A broken bridge marks a now-unused crossing"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.31",
+									"roll": {
+										"min": 32,
+										"max": 32
+									},
+									"text": "A series of ramshackle bridges connect high places"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.32",
+									"roll": {
+										"min": 33,
+										"max": 33
+									},
+									"text": "Phantom voices or song carry on the wind"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.33",
+									"roll": {
+										"min": 34,
+										"max": 34
+									},
+									"text": "A constructed bridge spans a river or gap"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.34",
+									"roll": {
+										"min": 35,
+										"max": 35
+									},
+									"text": "Something about this place spurs a memory"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.35",
+									"roll": {
+										"min": 36,
+										"max": 36
+									},
+									"text": "You encounter a small group of travelers"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.36",
+									"roll": {
+										"min": 37,
+										"max": 37
+									},
+									"text": "You discover the aftermath of a fight or battle"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.37",
+									"roll": {
+										"min": 38,
+										"max": 38
+									},
+									"text": "A recent landslide, collapse, or rockfall scars the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.38",
+									"roll": {
+										"min": 39,
+										"max": 39
+									},
+									"text": "Just ahead, a column of smoke rises into the sky"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.39",
+									"roll": {
+										"min": 40,
+										"max": 40
+									},
+									"text": "A cave opening is carved into the side of a hill or cliff"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.40",
+									"roll": {
+										"min": 41,
+										"max": 41
+									},
+									"text": "Several gravesites are here, each marked by an earthen or stone mound"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.41",
+									"roll": {
+										"min": 42,
+										"max": 42
+									},
+									"text": "An overlook offers an expansive view of the landscape ahead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.42",
+									"roll": {
+										"min": 43,
+										"max": 43
+									},
+									"text": "Nature flourishes here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.43",
+									"roll": {
+										"min": 44,
+										"max": 44
+									},
+									"text": "Abandoned construction is all that remains of a failed project"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.44",
+									"roll": {
+										"min": 45,
+										"max": 45
+									},
+									"text": "Ancient ruins stand here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.45",
+									"roll": {
+										"min": 46,
+										"max": 46
+									},
+									"text": "A great tree or rocky spire stands tall above its surroundings"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.46",
+									"roll": {
+										"min": 47,
+										"max": 47
+									},
+									"text": "Carrion birds circle overhead—a bad omen"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.47",
+									"roll": {
+										"min": 48,
+										"max": 48
+									},
+									"text": "You spot the banners of an armed force on the move"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.48",
+									"roll": {
+										"min": 49,
+										"max": 49
+									},
+									"text": "Mist rises from a plunging waterfall"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.49",
+									"roll": {
+										"min": 50,
+										"max": 50
+									},
+									"text": "You find disturbing remains or evidence of a violent death"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.50",
+									"roll": {
+										"min": 51,
+										"max": 51
+									},
+									"text": "A natural bridge spans a river or gap"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.51",
+									"roll": {
+										"min": 52,
+										"max": 52
+									},
+									"text": "Mystic stones or strange pillars stand here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.52",
+									"roll": {
+										"min": 53,
+										"max": 53
+									},
+									"text": "The landscape is strewn with a maze of rocky spires"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.53",
+									"roll": {
+										"min": 54,
+										"max": 54
+									},
+									"text": "Fallen trees or upturned earth mark a destructive path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.54",
+									"roll": {
+										"min": 55,
+										"max": 55
+									},
+									"text": "Cleared, cultivated, or barren ground stands apart from its surroundings"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.55",
+									"roll": {
+										"min": 56,
+										"max": 56
+									},
+									"text": "The nature of the landscape or environment changes"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.56",
+									"roll": {
+										"min": 57,
+										"max": 57
+									},
+									"text": "Ghostlights dance above the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.57",
+									"roll": {
+										"min": 58,
+										"max": 58
+									},
+									"text": "Scorched ground marks the location of a recent fire"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.58",
+									"roll": {
+										"min": 59,
+										"max": 59
+									},
+									"text": "Steam rises from bubbling pools"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.59",
+									"roll": {
+										"min": 60,
+										"max": 60
+									},
+									"text": "Stones or markings form a mystic circle"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.60",
+									"roll": {
+										"min": 61,
+										"max": 61
+									},
+									"text": "Creatures gather at a source of water"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.61",
+									"roll": {
+										"min": 62,
+										"max": 62
+									},
+									"text": "The path ascends a hill or ridgeline"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.62",
+									"roll": {
+										"min": 63,
+										"max": 63
+									},
+									"text": "Carved symbols or likenesses adorn the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.63",
+									"roll": {
+										"min": 64,
+										"max": 64
+									},
+									"text": "A great flying creature circles overhead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.64",
+									"roll": {
+										"min": 65,
+										"max": 65
+									},
+									"text": "A road or trail marks a well-used path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.65",
+									"roll": {
+										"min": 66,
+										"max": 66
+									},
+									"text": "The weather shifts, a portent of things to come"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.66",
+									"roll": {
+										"min": 67,
+										"max": 67
+									},
+									"text": "The skeleton of a massive animal or beast lies here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.67",
+									"roll": {
+										"min": 68,
+										"max": 68
+									},
+									"text": "A large stone bears an inscription or message"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.68",
+									"roll": {
+										"min": 69,
+										"max": 69
+									},
+									"text": "A ragged banner hangs from a leaning pole"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.69",
+									"roll": {
+										"min": 70,
+										"max": 70
+									},
+									"text": "A makeshift shelter or solitary home lies abandoned"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.70",
+									"roll": {
+										"min": 71,
+										"max": 71
+									},
+									"text": "A large creature hunts or forages here, but pays you no heed"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.71",
+									"roll": {
+										"min": 72,
+										"max": 72
+									},
+									"text": "Carrion animals pick at scattered remains"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.72",
+									"roll": {
+										"min": 73,
+										"max": 73
+									},
+									"text": "You hear the sounds of a nearby battle"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.73",
+									"roll": {
+										"min": 74,
+										"max": 74
+									},
+									"text": "You hear the calls of unusual wildlife"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.74",
+									"roll": {
+										"min": 75,
+										"max": 75
+									},
+									"text": "A spectral manifestation appears"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.75",
+									"roll": {
+										"min": 76,
+										"max": 76
+									},
+									"text": "Natural or carved steps lead up a slope or cliffside"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.76",
+									"roll": {
+										"min": 77,
+										"max": 77
+									},
+									"text": "An altar, shrine, or memorial marks a hallowed place"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.77",
+									"roll": {
+										"min": 78,
+										"max": 78
+									},
+									"text": "The landscape is divided by a ravine or fissure"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.78",
+									"roll": {
+										"min": 79,
+										"max": 79
+									},
+									"text": "A natural oasis stands amid an otherwise ruined or barren landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.79",
+									"roll": {
+										"min": 80,
+										"max": 80
+									},
+									"text": "A dry riverbed or trench cuts through the landscape like a scar"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.80",
+									"roll": {
+										"min": 81,
+										"max": 81
+									},
+									"text": "Nature is stunted or diseased in this place"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.81",
+									"roll": {
+										"min": 82,
+										"max": 82
+									},
+									"text": "An ancient monument or statue stands here"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.82",
+									"roll": {
+										"min": 83,
+										"max": 83
+									},
+									"text": "A shadowy path leads along a narrow canyon or pass"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.83",
+									"roll": {
+										"min": 84,
+										"max": 84
+									},
+									"text": "Tracks or claw marks reveal the passage of a large animal or beast"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.84",
+									"roll": {
+										"min": 85,
+										"max": 85
+									},
+									"text": "A caravan is camped here or passing through"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.85",
+									"roll": {
+										"min": 86,
+										"max": 86
+									},
+									"text": "Laborers toil at a worksite"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.86",
+									"roll": {
+										"min": 87,
+										"max": 87
+									},
+									"text": "A signal station, lookout, or tower sits on high ground"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.87",
+									"roll": {
+										"min": 88,
+										"max": 88
+									},
+									"text": "Scattered stones mark a toppled structure or monument"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.88",
+									"roll": {
+										"min": 89,
+										"max": 89
+									},
+									"text": "A lingering fog clings to the terrain"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.89",
+									"roll": {
+										"min": 90,
+										"max": 90
+									},
+									"text": "You top a rise, and catch sight of a trailing person or creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.90",
+									"roll": {
+										"min": 91,
+										"max": 91
+									},
+									"text": "Intricately stacked cairn stones mark a lonely gravesite or remembrance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.91",
+									"roll": {
+										"min": 92,
+										"max": 92
+									},
+									"text": "A promontory or summit rises above the landscape"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.92",
+									"roll": {
+										"min": 93,
+										"max": 93
+									},
+									"text": "A wagon or cart sits abandoned"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.93",
+									"roll": {
+										"min": 94,
+										"max": 94
+									},
+									"text": "A crudely-fashioned effigy watches over the surroundings"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.94",
+									"roll": {
+										"min": 95,
+										"max": 95
+									},
+									"text": "A sinkhole or pit leads to unseen depths"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.95",
+									"roll": {
+										"min": 96,
+										"max": 96
+									},
+									"text": "An unusual tree or rock formation stands apart from its surroundings"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.96",
+									"roll": {
+										"min": 97,
+										"max": 97
+									},
+									"text": "The path descends into a valley or basin"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.97",
+									"roll": {
+										"min": 98,
+										"max": 98
+									},
+									"text": "The ground is scattered with broken bones"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.98",
+									"roll": {
+										"min": 99,
+										"max": 99
+									},
+									"text": "The plants here are strangely at odds with their environment"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/waypoint.99",
+									"roll": {
+										"min": 100,
+										"max": 100
+									},
+									"text": "Blood-spattered ground or a bloody trail mark a violent end"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 55,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"peril": {
+							"_id": "oracle_rollable:lodestar/location/overland/peril",
+							"type": "oracle_rollable",
+							"name": "Peril",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal the nature of a perilous event or complication on a journey.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Lingering foul weather tests your endurance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "A piece of important gear is damaged or broken"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Provisions are lost, wasted, or spoiled"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "The weather takes a turn for the worse"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Rugged terrain or dense vegetation hampers your progress"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.5",
+									"roll": {
+										"min": 21,
+										"max": 23
+									},
+									"text": "An injury or old pain causes trouble"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.6",
+									"roll": {
+										"min": 24,
+										"max": 26
+									},
+									"text": "A cleverly camouflaged or hidden predator attacks"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.7",
+									"roll": {
+										"min": 27,
+										"max": 29
+									},
+									"text": "You stumble into the lair or nest of dangerous creatures"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.8",
+									"roll": {
+										"min": 30,
+										"max": 32
+									},
+									"text": "You are caught in a trap or ambush"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.9",
+									"roll": {
+										"min": 33,
+										"max": 35
+									},
+									"text": "An impassable path forces a dangerous detour"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.10",
+									"roll": {
+										"min": 36,
+										"max": 38
+									},
+									"text": "The path forces a treacherous crossing over a river or gap"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.11",
+									"roll": {
+										"min": 39,
+										"max": 41
+									},
+									"text": "A steep cliff or precipitous drop stands in your way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.12",
+									"roll": {
+										"min": 42,
+										"max": 44
+									},
+									"text": "Confounding paths cause you to lose your way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.13",
+									"roll": {
+										"min": 45,
+										"max": 47
+									},
+									"text": "Disease or sickness takes hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.14",
+									"roll": {
+										"min": 48,
+										"max": 50
+									},
+									"text": "You realize something important was lost or left behind"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.15",
+									"roll": {
+										"min": 51,
+										"max": 53
+									},
+									"text": "You come upon a settlement or camp in crisis"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.16",
+									"roll": {
+										"min": 54,
+										"max": 56
+									},
+									"text": "Someone who watches over this area makes a costly demand or threat"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.17",
+									"roll": {
+										"min": 57,
+										"max": 59
+									},
+									"text": "An enemy patrol or outpost guards this area"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.18",
+									"roll": {
+										"min": 60,
+										"max": 62
+									},
+									"text": "You encounter a dangerous animal or pack"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.19",
+									"roll": {
+										"min": 63,
+										"max": 65
+									},
+									"text": "Insects or small creatures swarm to attack"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.20",
+									"roll": {
+										"min": 66,
+										"max": 68
+									},
+									"text": "You are caught in a flood or forced to navigate a perilous waterway"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.21",
+									"roll": {
+										"min": 69,
+										"max": 71
+									},
+									"text": "You encounter a fellow traveler in peril"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.22",
+									"roll": {
+										"min": 72,
+										"max": 74
+									},
+									"text": "Fog or darkness hides a lurking danger"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.23",
+									"roll": {
+										"min": 75,
+										"max": 76
+									},
+									"text": "You suffer the effects of toxic plants or venomous creatures"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.24",
+									"roll": {
+										"min": 77,
+										"max": 78
+									},
+									"text": "You are caught within unnatural mist or darkness"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.25",
+									"roll": {
+										"min": 79,
+										"max": 80
+									},
+									"text": "A companion or fellow traveler stumbles into danger"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.26",
+									"roll": {
+										"min": 81,
+										"max": 82
+									},
+									"text": "Muddy ground or a quagmire threatens to drag you down"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.27",
+									"roll": {
+										"min": 83,
+										"max": 84
+									},
+									"text": "You encounter a monstrous beast"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.28",
+									"roll": {
+										"min": 85,
+										"max": 86
+									},
+									"text": "A deceptively peaceful location lures you into a false sense of safety"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.29",
+									"roll": {
+										"min": 87,
+										"max": 88
+									},
+									"text": "Spooked creatures stampede along your path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.30",
+									"roll": {
+										"min": 89,
+										"max": 90
+									},
+									"text": "A companion or fellow traveler is injured or falls ill"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.31",
+									"roll": {
+										"min": 91,
+										"max": 92
+									},
+									"text": "You face a dreadful vision or hallucination"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.32",
+									"roll": {
+										"min": 93,
+										"max": 94
+									},
+									"text": "A sinkhole or pit opens beneath you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.33",
+									"roll": {
+										"min": 95,
+										"max": 96
+									},
+									"text": "A supernatural entity seeks vengeance or absolution"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.34",
+									"roll": {
+										"min": 97,
+										"max": 98
+									},
+									"text": "Unstable terrain causes a rockfall or landslide"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/peril.35",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "Your presence triggers a spell or supernatural anomaly"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 58,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"opportunity": {
+							"_id": "oracle_rollable:lodestar/location/overland/opportunity",
+							"type": "oracle_rollable",
+							"name": "Opportunity",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal the nature of an unexpected and beneficial event on a journey.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Ideal weather takes hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "The terrain favors you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "There are plentiful hunting or foraging opportunities in this area"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "A clear path leads through otherwise dangerous terrain"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "You find an ideal location for a campsite"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.5",
+									"roll": {
+										"min": 21,
+										"max": 23
+									},
+									"text": "An awe-inspiring vista offers comfort or inspiration"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.6",
+									"roll": {
+										"min": 24,
+										"max": 26
+									},
+									"text": "You find a useful item"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.7",
+									"roll": {
+										"min": 27,
+										"max": 29
+									},
+									"text": "A helpful traveler crosses your path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.8",
+									"roll": {
+										"min": 30,
+										"max": 32
+									},
+									"text": "An intriguing site offers opportunities for exploration"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.9",
+									"roll": {
+										"min": 33,
+										"max": 35
+									},
+									"text": "A vantage point reveals a key landmark"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.10",
+									"roll": {
+										"min": 36,
+										"max": 38
+									},
+									"text": "A nearby settlement flies a friendly banner"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.11",
+									"roll": {
+										"min": 39,
+										"max": 41
+									},
+									"text": "Something about this journey sparks a fond or helpful memory"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.12",
+									"roll": {
+										"min": 42,
+										"max": 44
+									},
+									"text": "You encounter a helpful or useful animal"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.13",
+									"roll": {
+										"min": 45,
+										"max": 47
+									},
+									"text": "You encounter a friendly group of local denizens"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.14",
+									"roll": {
+										"min": 48,
+										"max": 50
+									},
+									"text": "A sheltered refuge offers a place to hide, plan, or recover"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.15",
+									"roll": {
+										"min": 51,
+										"max": 53
+									},
+									"text": "A monument or relic reveals something of the history of this land"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.16",
+									"roll": {
+										"min": 54,
+										"max": 56
+									},
+									"text": "You find plants or herbs with potentially helpful qualities"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.17",
+									"roll": {
+										"min": 57,
+										"max": 59
+									},
+									"text": "Tracks or a cooling campfire show that others have passed this way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.18",
+									"roll": {
+										"min": 60,
+										"max": 62
+									},
+									"text": "You are forewarned of a dangerous path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.19",
+									"roll": {
+										"min": 63,
+										"max": 65
+									},
+									"text": "A desolate settlement or camp offers scavenging opportunities"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.20",
+									"roll": {
+										"min": 66,
+										"max": 68
+									},
+									"text": "You find an opening to distract, escape, or avoid foes"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.21",
+									"roll": {
+										"min": 69,
+										"max": 71
+									},
+									"text": "A clue offers insight into a current quest or mystery"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.22",
+									"roll": {
+										"min": 72,
+										"max": 74
+									},
+									"text": "You encounter a potential benefactor in need of help"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.23",
+									"roll": {
+										"min": 75,
+										"max": 76
+									},
+									"text": "You learn or improve a useful skill"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.24",
+									"roll": {
+										"min": 77,
+										"max": 78
+									},
+									"text": "A caravan offers the potential comforts and safety of a community"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.25",
+									"roll": {
+										"min": 79,
+										"max": 80
+									},
+									"text": "You experience a helpful dream or vision"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.26",
+									"roll": {
+										"min": 81,
+										"max": 82
+									},
+									"text": "The terrain offers a defensible position against a threat"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.27",
+									"roll": {
+										"min": 83,
+										"max": 84
+									},
+									"text": "A supernatural entity offers helpful guidance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.28",
+									"roll": {
+										"min": 85,
+										"max": 86
+									},
+									"text": "You encounter a majestic or previously unknown creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.29",
+									"roll": {
+										"min": 87,
+										"max": 88
+									},
+									"text": "A lurking foe unwittingly reveals themselves, giving you the drop on them"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.30",
+									"roll": {
+										"min": 89,
+										"max": 90
+									},
+									"text": "You spot a friendly animal keeping pace with you—a good omen"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.31",
+									"roll": {
+										"min": 91,
+										"max": 92
+									},
+									"text": "A signpost or marker provides guidance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.32",
+									"roll": {
+										"min": 93,
+										"max": 94
+									},
+									"text": "An otherwise dangerous predator shows benign interest in you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.33",
+									"roll": {
+										"min": 95,
+										"max": 96
+									},
+									"text": "A stone or tree bears helpful or inspiring markings from past travelers"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.34",
+									"roll": {
+										"min": 97,
+										"max": 98
+									},
+									"text": "You experience a moment of fellowship or inner peace"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/overland/opportunity.35",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "You find an object or resource of great value"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 59,
+								"url": "https://ironswornrpg.com"
+							}
+						}
+					},
+					"collections": {},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 54,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"coastal_waters": {
+					"_id": "oracle_collection:lodestar/location/coastal_waters",
+					"type": "oracle_collection",
+					"name": "Coastal Waters",
+					"oracle_type": "tables",
+					"contents": {
+						"landmark": {
+							"_id": "oracle_rollable:lodestar/location/coastal_waters/landmark",
+							"type": "oracle_rollable",
+							"name": "Landmark",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to help envision a basic feature of the coastal waters as a journey waypoint or key location.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Anchorage",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Sargassum",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.2",
+									"roll": {
+										"min": 9,
+										"max": 13
+									},
+									"text": "Wreck",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.3",
+									"roll": {
+										"min": 14,
+										"max": 17
+									},
+									"text": "Harbor",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.4",
+									"roll": {
+										"min": 18,
+										"max": 21
+									},
+									"text": "Beacon",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.5",
+									"roll": {
+										"min": 22,
+										"max": 25
+									},
+									"text": "Shoal",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.6",
+									"roll": {
+										"min": 26,
+										"max": 30
+									},
+									"text": "Fjord",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.7",
+									"roll": {
+										"min": 31,
+										"max": 34
+									},
+									"text": "Estuary",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.8",
+									"roll": {
+										"min": 35,
+										"max": 38
+									},
+									"text": "Sea arch",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.9",
+									"roll": {
+										"min": 39,
+										"max": 42
+									},
+									"text": "Cove",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.10",
+									"roll": {
+										"min": 43,
+										"max": 46
+									},
+									"text": "Bay",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.11",
+									"roll": {
+										"min": 47,
+										"max": 50
+									},
+									"text": "Iceberg",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.12",
+									"roll": {
+										"min": 51,
+										"max": 55
+									},
+									"text": "Island",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.13",
+									"roll": {
+										"min": 56,
+										"max": 59
+									},
+									"text": "Settlement",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.14",
+									"roll": {
+										"min": 60,
+										"max": 63
+									},
+									"text": "Ice shelf",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.15",
+									"roll": {
+										"min": 64,
+										"max": 68
+									},
+									"text": "Sea cave",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.16",
+									"roll": {
+										"min": 69,
+										"max": 72
+									},
+									"text": "Ruins",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.17",
+									"roll": {
+										"min": 73,
+										"max": 76
+									},
+									"text": "Landing",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.18",
+									"roll": {
+										"min": 77,
+										"max": 80
+									},
+									"text": "Kelp forest",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.19",
+									"roll": {
+										"min": 81,
+										"max": 84
+									},
+									"text": "Sea stack",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.20",
+									"roll": {
+										"min": 85,
+										"max": 88
+									},
+									"text": "Islet",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.21",
+									"roll": {
+										"min": 89,
+										"max": 92
+									},
+									"text": "Beach",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.22",
+									"roll": {
+										"min": 93,
+										"max": 96
+									},
+									"text": "Sea cliff",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/landmark.23",
+									"roll": {
+										"min": 97,
+										"max": 100
+									},
+									"text": "Anomaly",
+									"_i18n": {
+										"text": {
+											"part_of_speech": "common_noun"
+										}
+									}
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 60,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"waypoint": {
+							"_id": "oracle_rollable:lodestar/location/coastal_waters/waypoint",
+							"type": "oracle_rollable",
+							"name": "Waypoint",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal a location, discovery, or event when you Undertake a Journey and reach a waypoint.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.0",
+									"roll": {
+										"min": 1,
+										"max": 2
+									},
+									"text": "A wrecked ship or boat lies broken upon rocks"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.1",
+									"roll": {
+										"min": 3,
+										"max": 4
+									},
+									"text": "Mist clings to a shoreline ruin"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.2",
+									"roll": {
+										"min": 5,
+										"max": 6
+									},
+									"text": "Dancing ribbons of colorful lights appear in a dark sky"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.3",
+									"roll": {
+										"min": 7,
+										"max": 8
+									},
+									"text": "The wind and waters are eerily calm"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.4",
+									"roll": {
+										"min": 9,
+										"max": 10
+									},
+									"text": "A ship is anchored in a sheltered bay"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.5",
+									"roll": {
+										"min": 11,
+										"max": 12
+									},
+									"text": "A wide river empties into the sea"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.6",
+									"roll": {
+										"min": 13,
+										"max": 14
+									},
+									"text": "A large animal or beast watches from the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.7",
+									"roll": {
+										"min": 15,
+										"max": 16
+									},
+									"text": "A ship flounders in high seas"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.8",
+									"roll": {
+										"min": 17,
+										"max": 18
+									},
+									"text": "A pod of orca glides past"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.9",
+									"roll": {
+										"min": 19,
+										"max": 20
+									},
+									"text": "An abandoned settlement is partially reclaimed by the sea"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.10",
+									"roll": {
+										"min": 21,
+										"max": 22
+									},
+									"text": "Waves break upon a wide rocky beach"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.11",
+									"roll": {
+										"min": 23,
+										"max": 24
+									},
+									"text": "A beached ship is under repair"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.12",
+									"roll": {
+										"min": 25,
+										"max": 26
+									},
+									"text": "The weather shifts, a portent of things to come"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.13",
+									"roll": {
+										"min": 27,
+										"max": 28
+									},
+									"text": "A waterfall spills from a seaside bluff"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.14",
+									"roll": {
+										"min": 29,
+										"max": 30
+									},
+									"text": "The skeletal ribs of an old wreck sit upon the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.15",
+									"roll": {
+										"min": 31,
+										"max": 32
+									},
+									"text": "Whalers or beast hunters prowl these waters in sleek ships"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.16",
+									"roll": {
+										"min": 33,
+										"max": 34
+									},
+									"text": "A ruin lies half-submerged in shallow waters"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.17",
+									"roll": {
+										"min": 35,
+										"max": 36
+									},
+									"text": "The water churns as a large school of fish flees a predator"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.18",
+									"roll": {
+										"min": 37,
+										"max": 38
+									},
+									"text": "A bleak-looking island appears uninhabited"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.19",
+									"roll": {
+										"min": 39,
+										"max": 40
+									},
+									"text": "A landed boat or ship sits upon the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.20",
+									"roll": {
+										"min": 41,
+										"max": 42
+									},
+									"text": "Imposing cliffs rise from the sea"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.21",
+									"roll": {
+										"min": 43,
+										"max": 44
+									},
+									"text": "A dense fog clings to the water"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.22",
+									"roll": {
+										"min": 45,
+										"max": 46
+									},
+									"text": "Boats and ships gather at a seaside settlement"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.23",
+									"roll": {
+										"min": 47,
+										"max": 48
+									},
+									"text": "Hordes of seabirds nest upon a guano-spattered sea stack"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.24",
+									"roll": {
+										"min": 49,
+										"max": 50
+									},
+									"text": "Whales crest the surface"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.25",
+									"roll": {
+										"min": 51,
+										"max": 52
+									},
+									"text": "Laborers toil at a waterside worksite"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.26",
+									"roll": {
+										"min": 53,
+										"max": 54
+									},
+									"text": "An ancient statue or monument stands on the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.27",
+									"roll": {
+										"min": 55,
+										"max": 56
+									},
+									"text": "Rocky shoals lie within shallow waters"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.28",
+									"roll": {
+										"min": 57,
+										"max": 58
+									},
+									"text": "Just under the surface, a thick kelp forest dances in the current"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.29",
+									"roll": {
+										"min": 59,
+										"max": 60
+									},
+									"text": "Fisher folk gather their catch"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.30",
+									"roll": {
+										"min": 61,
+										"max": 62
+									},
+									"text": "A column of smoke rises from the interior of an island"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.31",
+									"roll": {
+										"min": 63,
+										"max": 64
+									},
+									"text": "Gulls peck at a floating carcass"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.32",
+									"roll": {
+										"min": 65,
+										"max": 66
+									},
+									"text": "A makeshift shelter or solitary home sits on the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.33",
+									"roll": {
+										"min": 67,
+										"max": 68
+									},
+									"text": "Darkness beckons from within a sea cave"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.34",
+									"roll": {
+										"min": 69,
+										"max": 70
+									},
+									"text": "A storm gathers in the distance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.35",
+									"roll": {
+										"min": 71,
+										"max": 72
+									},
+									"text": "You spot a seaside camp or settlement"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.36",
+									"roll": {
+										"min": 73,
+										"max": 74
+									},
+									"text": "Seals rest on a wave-swept rock"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.37",
+									"roll": {
+										"min": 75,
+										"max": 76
+									},
+									"text": "A boat or ship comes into view"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.38",
+									"roll": {
+										"min": 77,
+										"max": 78
+									},
+									"text": "The water stirs with the movement of a great creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.39",
+									"roll": {
+										"min": 79,
+										"max": 80
+									},
+									"text": "Steep cliffs flank a narrow fjord"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.40",
+									"roll": {
+										"min": 81,
+										"max": 81
+									},
+									"text": "A rogue iceberg drifts with the current"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.41",
+									"roll": {
+										"min": 82,
+										"max": 82
+									},
+									"text": "A long line of ships appears on the horizon"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.42",
+									"roll": {
+										"min": 83,
+										"max": 83
+									},
+									"text": "Sharks circle menacingly"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.43",
+									"roll": {
+										"min": 84,
+										"max": 84
+									},
+									"text": "A capsized ship or boat drifts on the water"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.44",
+									"roll": {
+										"min": 85,
+										"max": 85
+									},
+									"text": "A beacon tower glimmers with a warning flame"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.45",
+									"roll": {
+										"min": 86,
+										"max": 86
+									},
+									"text": "Debris collects in a swirling eddy"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.46",
+									"roll": {
+										"min": 87,
+										"max": 87
+									},
+									"text": "Eerie voices carry on the wind"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.47",
+									"roll": {
+										"min": 88,
+										"max": 88
+									},
+									"text": "The temperature shifts unnaturally"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.48",
+									"roll": {
+										"min": 89,
+										"max": 89
+									},
+									"text": "A shelf of glacial ice divides sea from land"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.49",
+									"roll": {
+										"min": 90,
+										"max": 90
+									},
+									"text": "You spot ships engaged in a battle"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.50",
+									"roll": {
+										"min": 91,
+										"max": 91
+									},
+									"text": "A lookout post or tower stands at water's edge"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.51",
+									"roll": {
+										"min": 92,
+										"max": 92
+									},
+									"text": "A narrow channel leads through an icy expanse"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.52",
+									"roll": {
+										"min": 93,
+										"max": 93
+									},
+									"text": "A whale corpse lies bloated on a beach"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.53",
+									"roll": {
+										"min": 94,
+										"max": 94
+									},
+									"text": "A large natural arch towers over the surrounding waters"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.54",
+									"roll": {
+										"min": 95,
+										"max": 95
+									},
+									"text": "A great flying creature circles overhead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.55",
+									"roll": {
+										"min": 96,
+										"max": 96
+									},
+									"text": "A bridge connects the mainland to an offshore island"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.56",
+									"roll": {
+										"min": 97,
+										"max": 97
+									},
+									"text": "Mystic stones or strange pillars stand on the shore"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.57",
+									"roll": {
+										"min": 98,
+										"max": 98
+									},
+									"text": "A stone fortification stands at water's edge"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.58",
+									"roll": {
+										"min": 99,
+										"max": 99
+									},
+									"text": "Thickly-packed seaweed carpets the water"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/waypoint.59",
+									"roll": {
+										"min": 100,
+										"max": 100
+									},
+									"text": "A spectral manifestation appears"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 61,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"peril": {
+							"_id": "oracle_rollable:lodestar/location/coastal_waters/peril",
+							"type": "oracle_rollable",
+							"name": "Peril",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal the nature of a perilous event or complication on a journey.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Provisions are lost, wasted, or spoiled"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "The weather takes a turn for the worse"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Rough seas hamper your progress"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Lingering foul weather tests your endurance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "A piece of important gear is damaged or broken"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.5",
+									"roll": {
+										"min": 21,
+										"max": 23
+									},
+									"text": "Rocky shoals or shallows slow your progress"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.6",
+									"roll": {
+										"min": 24,
+										"max": 26
+									},
+									"text": "Powerful currents or winds pull you off course"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.7",
+									"roll": {
+										"min": 27,
+										"max": 29
+									},
+									"text": "You realize something important was lost or left behind"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.8",
+									"roll": {
+										"min": 30,
+										"max": 32
+									},
+									"text": "An injury or old pain causes trouble"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.9",
+									"roll": {
+										"min": 33,
+										"max": 35
+									},
+									"text": "Fog or darkness hides a lurking danger"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.10",
+									"roll": {
+										"min": 36,
+										"max": 38
+									},
+									"text": "A sudden storm assails you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.11",
+									"roll": {
+										"min": 39,
+										"max": 41
+									},
+									"text": "A rogue wave crashes into you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.12",
+									"roll": {
+										"min": 42,
+										"max": 44
+									},
+									"text": "A critical component of your watercraft is lost or damaged"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.13",
+									"roll": {
+										"min": 45,
+										"max": 47
+									},
+									"text": "Disease or sickness takes hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.14",
+									"roll": {
+										"min": 48,
+										"max": 50
+									},
+									"text": "You lose your way amidst an accursed fog"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.15",
+									"roll": {
+										"min": 51,
+										"max": 53
+									},
+									"text": "A ship or boat is in distress"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.16",
+									"roll": {
+										"min": 54,
+										"max": 56
+									},
+									"text": "Your hull is fouled or leaking"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.17",
+									"roll": {
+										"min": 57,
+										"max": 59
+									},
+									"text": "An enemy ship closes on you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.18",
+									"roll": {
+										"min": 60,
+										"max": 62
+									},
+									"text": "You are lost or off course"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.19",
+									"roll": {
+										"min": 63,
+										"max": 65
+									},
+									"text": "Dangerous creatures harass your watercraft"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.20",
+									"roll": {
+										"min": 66,
+										"max": 68
+									},
+									"text": "You encounter a monstrous sea creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.21",
+									"roll": {
+										"min": 69,
+										"max": 71
+									},
+									"text": "You are trapped in frozen seas"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.22",
+									"roll": {
+										"min": 72,
+										"max": 74
+									},
+									"text": "You spot a settlement or camp in crisis"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.23",
+									"roll": {
+										"min": 75,
+										"max": 76
+									},
+									"text": "A flying beast attacks"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.24",
+									"roll": {
+										"min": 77,
+										"max": 78
+									},
+									"text": "You are caught within unnatural mist or darkness"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.25",
+									"roll": {
+										"min": 79,
+										"max": 80
+									},
+									"text": "A blockade of ships stands in your way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.26",
+									"roll": {
+										"min": 81,
+										"max": 82
+									},
+									"text": "You face a dreadful apparition or hallucination"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.27",
+									"roll": {
+										"min": 83,
+										"max": 84
+									},
+									"text": "A companion or fellow traveler is injured or falls ill"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.28",
+									"roll": {
+										"min": 85,
+										"max": 86
+									},
+									"text": "A supernatural entity seeks vengeance or absolution"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.29",
+									"roll": {
+										"min": 87,
+										"max": 88
+									},
+									"text": "A companion or fellow traveler draws the attention of a new danger"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.30",
+									"roll": {
+										"min": 89,
+										"max": 90
+									},
+									"text": "An unnatural mist or darkness surrounds you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.31",
+									"roll": {
+										"min": 91,
+										"max": 92
+									},
+									"text": "A dangerous current or whirlpool takes hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.32",
+									"roll": {
+										"min": 93,
+										"max": 94
+									},
+									"text": "You run aground in shallow waters"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.33",
+									"roll": {
+										"min": 95,
+										"max": 96
+									},
+									"text": "A maze of rocky outcroppings or ice flows forces careful navigation"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.34",
+									"roll": {
+										"min": 97,
+										"max": 98
+									},
+									"text": "A companion or fellow traveler causes a delay"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/peril.35",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "Your presence triggers a spell or supernatural anomaly"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 64,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"opportunity": {
+							"_id": "oracle_rollable:lodestar/location/coastal_waters/opportunity",
+							"type": "oracle_rollable",
+							"name": "Opportunity",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"summary": "Use this oracle to reveal the nature of an unexpected and beneficial event on a journey.",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.0",
+									"roll": {
+										"min": 1,
+										"max": 5
+									},
+									"text": "A fortuitous wind or current speeds your way"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.1",
+									"roll": {
+										"min": 6,
+										"max": 10
+									},
+									"text": "Ideal weather takes hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.2",
+									"roll": {
+										"min": 11,
+										"max": 15
+									},
+									"text": "There are plentiful fishing opportunities in these waters"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.3",
+									"roll": {
+										"min": 16,
+										"max": 19
+									},
+									"text": "A desolate shoreline settlement or camp offers scavenging opportunities"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.4",
+									"roll": {
+										"min": 20,
+										"max": 23
+									},
+									"text": "A nearby settlement flies a friendly banner"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.5",
+									"roll": {
+										"min": 24,
+										"max": 27
+									},
+									"text": "A nearby shore offers plentiful opportunities for hunting or foraging"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.6",
+									"roll": {
+										"min": 28,
+										"max": 31
+									},
+									"text": "A sheltered bay offers safe harbor"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.7",
+									"roll": {
+										"min": 32,
+										"max": 35
+									},
+									"text": "An intriguing shoreline location offers opportunities for exploration"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.8",
+									"roll": {
+										"min": 36,
+										"max": 39
+									},
+									"text": "You find an ideal location for a safe landing"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.9",
+									"roll": {
+										"min": 40,
+										"max": 43
+									},
+									"text": "You find clear passage through otherwise perilous seas"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.10",
+									"roll": {
+										"min": 44,
+										"max": 47
+									},
+									"text": "You spot a shipwreck ripe for the picking"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.11",
+									"roll": {
+										"min": 48,
+										"max": 51
+									},
+									"text": "Something about this journey sparks a fond or helpful memory"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.12",
+									"roll": {
+										"min": 52,
+										"max": 54
+									},
+									"text": "A clue offers insight into a current quest or mystery"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.13",
+									"roll": {
+										"min": 55,
+										"max": 57
+									},
+									"text": "A friendly sea creature or bird keeps pace with you—a good omen"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.14",
+									"roll": {
+										"min": 58,
+										"max": 60
+									},
+									"text": "A large ship offers the potential comforts and safety of a community"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.15",
+									"roll": {
+										"min": 61,
+										"max": 63
+									},
+									"text": "An awe-inspiring vista offers comfort or inspiration"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.16",
+									"roll": {
+										"min": 64,
+										"max": 66
+									},
+									"text": "You are forewarned of a lurking danger"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.17",
+									"roll": {
+										"min": 67,
+										"max": 69
+									},
+									"text": "You encounter a helpful or useful animal"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.18",
+									"roll": {
+										"min": 70,
+										"max": 72
+									},
+									"text": "You experience a moment of fellowship or inner peace"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.19",
+									"roll": {
+										"min": 73,
+										"max": 75
+									},
+									"text": "You spot a friendly ship or boat"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.20",
+									"roll": {
+										"min": 76,
+										"max": 78
+									},
+									"text": "A key landmark comes into view"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.21",
+									"roll": {
+										"min": 79,
+										"max": 81
+									},
+									"text": "A helpful mariner crosses your path"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.22",
+									"roll": {
+										"min": 82,
+										"max": 84
+									},
+									"text": "A monument or relic reveals something of the history of this area"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.23",
+									"roll": {
+										"min": 85,
+										"max": 87
+									},
+									"text": "The winds or terrain offer the means to avoid a threat"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.24",
+									"roll": {
+										"min": 88,
+										"max": 90
+									},
+									"text": "You learn or improve a helpful skill"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.25",
+									"roll": {
+										"min": 91,
+										"max": 92
+									},
+									"text": "A supernatural entity offers helpful guidance"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.26",
+									"roll": {
+										"min": 93,
+										"max": 94
+									},
+									"text": "An otherwise dangerous sea creature shows benign interest in you"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.27",
+									"roll": {
+										"min": 95,
+										"max": 96
+									},
+									"text": "You encounter a majestic or previously unknown creature"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.28",
+									"roll": {
+										"min": 97,
+										"max": 98
+									},
+									"text": "You experience a helpful dream or vision"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/location/coastal_waters/opportunity.29",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "You spot an object or resource of great value"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 65,
+								"url": "https://ironswornrpg.com"
+							}
+						}
+					},
+					"collections": {},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 60,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 54,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"magic": {
+			"_id": "oracle_collection:lodestar/magic",
+			"type": "oracle_collection",
+			"name": "Magic Oracles",
+			"oracle_type": "tables",
+			"contents": {
+				"ritual_backlash": {
+					"_id": "oracle_rollable:lodestar/magic/ritual_backlash",
+					"type": "oracle_rollable",
+					"name": "Ritual Backlash",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Those who deal in magic may find themselves at the mercy of chaos. This oracle can supplement, or replace, the Pay the Price table when resolving the outcome of a failed ritual or other negative interaction with mystical forces. Use this oracle in dramatic moments, or to introduce an unexpected outcome triggered by a match.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.0",
+							"roll": {
+								"min": 1,
+								"max": 4
+							},
+							"text": "Your ritual has the opposite effect."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.1",
+							"roll": {
+								"min": 5,
+								"max": 8
+							},
+							"text": "You are sapped of strength."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.2",
+							"roll": {
+								"min": 9,
+								"max": 12
+							},
+							"text": "Your friend, ally, or companion is adversely affected."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.3",
+							"roll": {
+								"min": 13,
+								"max": 16
+							},
+							"text": "You destroy an important object."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.4",
+							"roll": {
+								"min": 17,
+								"max": 20
+							},
+							"text": "You inadvertently summon a spirit or undead being."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.5",
+							"roll": {
+								"min": 21,
+								"max": 24
+							},
+							"text": "You collapse, and drift into a troubled sleep."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.6",
+							"roll": {
+								"min": 25,
+								"max": 28
+							},
+							"text": "You undergo a physical torment which leaves its mark upon you."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.7",
+							"roll": {
+								"min": 29,
+								"max": 32
+							},
+							"text": "You hear ghostly voices whispering of dark portents."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.8",
+							"roll": {
+								"min": 33,
+								"max": 36
+							},
+							"text": "You find yourself in another place without memory of how you got there."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.9",
+							"roll": {
+								"min": 37,
+								"max": 40
+							},
+							"text": "You alert someone or something to your presence."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.10",
+							"roll": {
+								"min": 41,
+								"max": 44
+							},
+							"text": "You are not yourself, and act against a friend, ally, or companion."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.11",
+							"roll": {
+								"min": 45,
+								"max": 48
+							},
+							"text": "You affect your surroundings, causing a disturbance or potential harm."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.12",
+							"roll": {
+								"min": 49,
+								"max": 52
+							},
+							"text": "You waste resources."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.13",
+							"roll": {
+								"min": 53,
+								"max": 56
+							},
+							"text": "You suffer the loss of a sense for several hours."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.14",
+							"roll": {
+								"min": 57,
+								"max": 60
+							},
+							"text": "You lose your connection to magic for a day or so."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.15",
+							"roll": {
+								"min": 61,
+								"max": 64
+							},
+							"text": "Your ritual affects the target in an unexpected and problematic way."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.16",
+							"roll": {
+								"min": 65,
+								"max": 68
+							},
+							"text": "Your ritual reveals a surprising and troubling truth."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.17",
+							"roll": {
+								"min": 69,
+								"max": 72
+							},
+							"text": "You are tempted by dark powers."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.18",
+							"roll": {
+								"min": 73,
+								"max": 76
+							},
+							"text": "You see a troubling vision of your future."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.19",
+							"roll": {
+								"min": 77,
+								"max": 80
+							},
+							"text": "You can't perform this ritual again until you acquire a key component."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.20",
+							"roll": {
+								"min": 81,
+								"max": 84
+							},
+							"text": "You develop a strange fear or compulsion."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.21",
+							"roll": {
+								"min": 85,
+								"max": 88
+							},
+							"text": "Your ritual causes creatures to exhibit strange or aggressive behavior."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.22",
+							"roll": {
+								"min": 89,
+								"max": 92
+							},
+							"text": "You are tormented by an apparition from your past."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.23",
+							"roll": {
+								"min": 93,
+								"max": 96
+							},
+							"text": "You are wracked with sudden sickness."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/ritual_backlash.24",
+							"roll": {
+								"min": 97,
+								"max": 100
+							},
+							"text": "Roll twice; if they are the same result, make it worse.",
+							"oracle_rolls": [
+								{
+									"oracle": null,
+									"dice": null,
+									"auto": true,
+									"duplicates": "make_it_worse",
+									"number_of_rolls": 2
+								}
+							]
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 96,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"mystic_effect": {
+					"_id": "oracle_rollable:lodestar/magic/mystic_effect",
+					"type": "oracle_rollable",
+					"name": "Mystic Effect",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to reveal the nature or outcome of a mystic power, ritual effect, or supernatural phenomenon.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.0",
+							"roll": {
+								"min": 1,
+								"max": 6
+							},
+							"text": "Drain the life from a target."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.1",
+							"roll": {
+								"min": 7,
+								"max": 8
+							},
+							"text": "Disintegrate or decay objects."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.2",
+							"roll": {
+								"min": 9,
+								"max": 10
+							},
+							"text": "Awaken an ancient being."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.3",
+							"roll": {
+								"min": 11,
+								"max": 12
+							},
+							"text": "Summon a monstrous creature."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.4",
+							"roll": {
+								"min": 13,
+								"max": 14
+							},
+							"text": "Bind to a vow or task."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.5",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Give life to inanimate forms."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.6",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Unleash a plague."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.7",
+							"roll": {
+								"min": 19,
+								"max": 20
+							},
+							"text": "Control elemental forces."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.8",
+							"roll": {
+								"min": 21,
+								"max": 22
+							},
+							"text": "Erase or suppress memories."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.9",
+							"roll": {
+								"min": 23,
+								"max": 24
+							},
+							"text": "Shroud in lasting darkness."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.10",
+							"roll": {
+								"min": 25,
+								"max": 26
+							},
+							"text": "Alter surrounding environment."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.11",
+							"roll": {
+								"min": 27,
+								"max": 28
+							},
+							"text": "Bind to a location."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.12",
+							"roll": {
+								"min": 29,
+								"max": 30
+							},
+							"text": "Inflict cursed luck."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.13",
+							"roll": {
+								"min": 31,
+								"max": 32
+							},
+							"text": "Incite negative emotions."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.14",
+							"roll": {
+								"min": 33,
+								"max": 34
+							},
+							"text": "Awaken latent powers in another."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.15",
+							"roll": {
+								"min": 35,
+								"max": 36
+							},
+							"text": "Inflict aging or wasting."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.16",
+							"roll": {
+								"min": 37,
+								"max": 38
+							},
+							"text": "Bind to a restless spirit."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.17",
+							"roll": {
+								"min": 39,
+								"max": 40
+							},
+							"text": "Grant horrifying knowledge."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.18",
+							"roll": {
+								"min": 41,
+								"max": 42
+							},
+							"text": "Awaken or animate the dead."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.19",
+							"roll": {
+								"min": 43,
+								"max": 44
+							},
+							"text": "Incite an obsession."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.20",
+							"roll": {
+								"min": 45,
+								"max": 46
+							},
+							"text": "Manifest inner fears."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.21",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Reveal hidden truths."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.22",
+							"roll": {
+								"min": 49,
+								"max": 50
+							},
+							"text": "Commune with spirits."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.23",
+							"roll": {
+								"min": 51,
+								"max": 52
+							},
+							"text": "Control weather or environment."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.24",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Reveal past events."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.25",
+							"roll": {
+								"min": 55,
+								"max": 56
+							},
+							"text": "Emit destructive energies."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.26",
+							"roll": {
+								"min": 57,
+								"max": 58
+							},
+							"text": "Alter the flow of time."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.27",
+							"roll": {
+								"min": 59,
+								"max": 60
+							},
+							"text": "Inflict a consuming need."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.28",
+							"roll": {
+								"min": 61,
+								"max": 62
+							},
+							"text": "Create hallucinations or illusions."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.29",
+							"roll": {
+								"min": 63,
+								"max": 64
+							},
+							"text": "Trigger a celestial event."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.30",
+							"roll": {
+								"min": 65,
+								"max": 66
+							},
+							"text": "Summon a swarm of creatures."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.31",
+							"roll": {
+								"min": 67,
+								"max": 68
+							},
+							"text": "Reveal distant places."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.32",
+							"roll": {
+								"min": 69,
+								"max": 70
+							},
+							"text": "Absorb energy or essence."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.33",
+							"roll": {
+								"min": 71,
+								"max": 72
+							},
+							"text": "Banish to another reality."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.34",
+							"roll": {
+								"min": 73,
+								"max": 74
+							},
+							"text": "Banish to another location."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.35",
+							"roll": {
+								"min": 75,
+								"max": 76
+							},
+							"text": "Inflict prophetic visions."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.36",
+							"roll": {
+								"min": 77,
+								"max": 78
+							},
+							"text": "Inflict dreadful transformations."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.37",
+							"roll": {
+								"min": 79,
+								"max": 80
+							},
+							"text": "Inflict sickness or weakness."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.38",
+							"roll": {
+								"min": 81,
+								"max": 82
+							},
+							"text": "Absorb life."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.39",
+							"roll": {
+								"min": 83,
+								"max": 84
+							},
+							"text": "Spread corruption or blight."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.40",
+							"roll": {
+								"min": 85,
+								"max": 86
+							},
+							"text": "Brand with a cursed mark."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.41",
+							"roll": {
+								"min": 87,
+								"max": 88
+							},
+							"text": "Destroy terrain or architecture."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.42",
+							"roll": {
+								"min": 89,
+								"max": 90
+							},
+							"text": "Grant a lasting boon—at a cost."
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/magic/mystic_effect.43",
+							"roll": {
+								"min": 91,
+								"max": 100
+							},
+							"text": "Roll twice.",
+							"oracle_rolls": [
+								{
+									"oracle": null,
+									"dice": null,
+									"auto": true,
+									"duplicates": "reroll",
+									"number_of_rolls": 2
+								}
+							]
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 97,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 96,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"scale": {
+			"_id": "oracle_collection:lodestar/scale",
+			"type": "oracle_collection",
+			"name": "Scale Oracles",
+			"oracle_type": "tables",
+			"summary": "Use these oracles to help answer a question related to the scale, extent, or capability of something.",
+			"contents": {
+				"rank": {
+					"_id": "oracle_rollable:lodestar/scale/rank",
+					"type": "oracle_rollable",
+					"name": "Rank",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to randomly set the challenge rank of a quest, journey, or foe.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/scale/rank.0",
+							"roll": {
+								"min": 1,
+								"max": 15
+							},
+							"text": "Troublesome"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/scale/rank.1",
+							"roll": {
+								"min": 16,
+								"max": 35
+							},
+							"text": "Dangerous"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/scale/rank.2",
+							"roll": {
+								"min": 36,
+								"max": 65
+							},
+							"text": "Formidable"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/scale/rank.3",
+							"roll": {
+								"min": 66,
+								"max": 85
+							},
+							"text": "Extreme"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/scale/rank.4",
+							"roll": {
+								"min": 86,
+								"max": 100
+							},
+							"text": "Epic"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 99,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {
+				"magnitude": {
+					"_id": "oracle_collection:lodestar/scale/magnitude",
+					"type": "oracle_collection",
+					"name": "Magnitude",
+					"oracle_type": "tables",
+					"summary": "Ask your question, choose one of the following tables, and roll to reveal the answer.",
+					"contents": {
+						"size": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/size",
+							"type": "oracle_rollable",
+							"name": "Size",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/size.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Undersized"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/size.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Small"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/size.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Medium"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/size.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Large"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/size.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Huge"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"number": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/number",
+							"type": "oracle_rollable",
+							"name": "Number",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/number.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "None / one"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/number.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Few"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/number.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Several"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/number.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Many"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/number.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Countless"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"distance": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/distance",
+							"type": "oracle_rollable",
+							"name": "Distance",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Very close"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Near"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Far"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Remote"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/distance.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Inaccessible"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"time": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/time",
+							"type": "oracle_rollable",
+							"name": "Time",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/time.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Fleeting"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/time.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Short"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/time.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Moderate"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/time.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Lengthy"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/time.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Eternal"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"power": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/power",
+							"type": "oracle_rollable",
+							"name": "Power",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/power.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Weak"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/power.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Minor"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/power.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Capable"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/power.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Strong"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/power.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Overwhelming"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"complexity": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/complexity",
+							"type": "oracle_rollable",
+							"name": "Complexity",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Simple"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Basic"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Manageable"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Complicated"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/complexity.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Bewildering"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"value": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/value",
+							"type": "oracle_rollable",
+							"name": "Value",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/value.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Worthless"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/value.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Cheap"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/value.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Common"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/value.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Valuable"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/value.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Priceless"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"influence": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/influence",
+							"type": "oracle_rollable",
+							"name": "Influence",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Limited"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Isolated"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Localized"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Far-reaching"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/influence.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Dominant"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"disposition": {
+							"_id": "oracle_rollable:lodestar/scale/magnitude/disposition",
+							"type": "oracle_rollable",
+							"name": "Disposition",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Friendly"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.1",
+									"roll": {
+										"min": 16,
+										"max": 35
+									},
+									"text": "Open"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.2",
+									"roll": {
+										"min": 36,
+										"max": 65
+									},
+									"text": "Wary"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.3",
+									"roll": {
+										"min": 66,
+										"max": 85
+									},
+									"text": "Threatening"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/scale/magnitude/disposition.4",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Hostile"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 98,
+								"url": "https://ironswornrpg.com"
+							}
+						}
+					},
+					"collections": {},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 98,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 98,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"settlement": {
+			"_id": "oracle_collection:lodestar/settlement",
+			"type": "oracle_collection",
+			"name": "Settlement Oracles",
+			"oracle_type": "tables",
+			"enhances": [
+				"oracle_collection:classic/settlement"
+			],
+			"contents": {
+				"condition": {
+					"_id": "oracle_rollable:lodestar/settlement/condition",
+					"type": "oracle_rollable",
+					"name": "Condition",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.0",
+							"roll": {
+								"min": 1,
+								"max": 5
+							},
+							"text": "Abandoned"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.1",
+							"roll": {
+								"min": 6,
+								"max": 10
+							},
+							"text": "Devastated"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.2",
+							"roll": {
+								"min": 11,
+								"max": 15
+							},
+							"text": "Besieged"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.3",
+							"roll": {
+								"min": 16,
+								"max": 20
+							},
+							"text": "Under construction"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.4",
+							"roll": {
+								"min": 21,
+								"max": 35
+							},
+							"text": "Wretched"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.5",
+							"roll": {
+								"min": 36,
+								"max": 50
+							},
+							"text": "Ramshackle"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.6",
+							"roll": {
+								"min": 51,
+								"max": 70
+							},
+							"text": "Modest"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.7",
+							"roll": {
+								"min": 71,
+								"max": 85
+							},
+							"text": "Well-kept"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.8",
+							"roll": {
+								"min": 86,
+								"max": 95
+							},
+							"text": "Prosperous"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/condition.9",
+							"roll": {
+								"min": 96,
+								"max": 100
+							},
+							"text": "Grand"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 64,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"disposition": {
+					"_id": "oracle_rollable:lodestar/settlement/disposition",
+					"type": "oracle_rollable",
+					"name": "Disposition",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.0",
+							"roll": {
+								"min": 1,
+								"max": 5
+							},
+							"text": "Hostile"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.1",
+							"roll": {
+								"min": 6,
+								"max": 15
+							},
+							"text": "Threatening"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.2",
+							"roll": {
+								"min": 16,
+								"max": 25
+							},
+							"text": "Demanding"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.3",
+							"roll": {
+								"min": 26,
+								"max": 35
+							},
+							"text": "Unwelcoming"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.4",
+							"roll": {
+								"min": 36,
+								"max": 50
+							},
+							"text": "Wary"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.5",
+							"roll": {
+								"min": 51,
+								"max": 60
+							},
+							"text": "Indifferent"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.6",
+							"roll": {
+								"min": 61,
+								"max": 70
+							},
+							"text": "In need"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.7",
+							"roll": {
+								"min": 71,
+								"max": 80
+							},
+							"text": "Welcoming"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.8",
+							"roll": {
+								"min": 81,
+								"max": 90
+							},
+							"text": "Friendly"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/disposition.9",
+							"roll": {
+								"min": 91,
+								"max": 100
+							},
+							"text": "Helpful"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 64,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"first_look": {
+					"_id": "oracle_rollable:lodestar/settlement/first_look",
+					"type": "oracle_rollable",
+					"name": "First Look",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.0",
+							"roll": {
+								"min": 1,
+								"max": 2
+							},
+							"text": "At a crossroads"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.1",
+							"roll": {
+								"min": 3,
+								"max": 4
+							},
+							"text": "Beacon or signal fire"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.2",
+							"roll": {
+								"min": 5,
+								"max": 6
+							},
+							"text": "Boundary of standing stones"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.3",
+							"roll": {
+								"min": 7,
+								"max": 8
+							},
+							"text": "Breached or collapsed wall"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.4",
+							"roll": {
+								"min": 9,
+								"max": 10
+							},
+							"text": "Built among ancient ruins"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.5",
+							"roll": {
+								"min": 11,
+								"max": 12
+							},
+							"text": "Built on a hill or crag"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.6",
+							"roll": {
+								"min": 13,
+								"max": 14
+							},
+							"text": "Built over or beside water"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.7",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Carved animal motifs"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.8",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Central tree"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.9",
+							"roll": {
+								"min": 19,
+								"max": 20
+							},
+							"text": "Building a prominent structure"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.10",
+							"roll": {
+								"min": 21,
+								"max": 22
+							},
+							"text": "Decorated for a festival"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.11",
+							"roll": {
+								"min": 23,
+								"max": 24
+							},
+							"text": "Dense smoke from worksites"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.12",
+							"roll": {
+								"min": 25,
+								"max": 26
+							},
+							"text": "Nearby encampment"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.13",
+							"roll": {
+								"min": 27,
+								"max": 28
+							},
+							"text": "Encroaching woodland"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.14",
+							"roll": {
+								"min": 29,
+								"max": 30
+							},
+							"text": "Expansive fields or agriculture"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.15",
+							"roll": {
+								"min": 31,
+								"max": 32
+							},
+							"text": "Large barrow mound"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.16",
+							"roll": {
+								"min": 33,
+								"max": 34
+							},
+							"text": "Filled with song and music"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.17",
+							"roll": {
+								"min": 35,
+								"max": 36
+							},
+							"text": "Flying a familiar banner"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.18",
+							"roll": {
+								"min": 37,
+								"max": 38
+							},
+							"text": "Hastily improvised defenses"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.19",
+							"roll": {
+								"min": 39,
+								"max": 40
+							},
+							"text": "Heavily armed guards"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.20",
+							"roll": {
+								"min": 41,
+								"max": 42
+							},
+							"text": "Hung with charms and wards"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.21",
+							"roll": {
+								"min": 43,
+								"max": 44
+							},
+							"text": "In the shadow of a terrain feature"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.22",
+							"roll": {
+								"min": 45,
+								"max": 46
+							},
+							"text": "Large communal building"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.23",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Numerous grazing animals"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.24",
+							"roll": {
+								"min": 49,
+								"max": 50
+							},
+							"text": "Protected by stout walls"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.25",
+							"roll": {
+								"min": 51,
+								"max": 52
+							},
+							"text": "Ringed by a moat or ditch"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.26",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Sections divided by walls"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.27",
+							"roll": {
+								"min": 55,
+								"max": 56
+							},
+							"text": "Watchtowers or lookouts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.28",
+							"roll": {
+								"min": 57,
+								"max": 57
+							},
+							"text": "Adorned with colorful banners"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.29",
+							"roll": {
+								"min": 58,
+								"max": 58
+							},
+							"text": "Armed with heavy weapons"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.30",
+							"roll": {
+								"min": 59,
+								"max": 59
+							},
+							"text": "Built into the terrain"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.31",
+							"roll": {
+								"min": 60,
+								"max": 60
+							},
+							"text": "Burning pit or pyre"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.32",
+							"roll": {
+								"min": 61,
+								"max": 61
+							},
+							"text": "Circling carrion birds"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.33",
+							"roll": {
+								"min": 62,
+								"max": 62
+							},
+							"text": "Connected by bridges"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.34",
+							"roll": {
+								"min": 63,
+								"max": 63
+							},
+							"text": "Large monolith or tower"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.35",
+							"roll": {
+								"min": 64,
+								"max": 64
+							},
+							"text": "Large statue or effigy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.36",
+							"roll": {
+								"min": 65,
+								"max": 65
+							},
+							"text": "Loud laughter or merrymaking"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.37",
+							"roll": {
+								"min": 66,
+								"max": 66
+							},
+							"text": "Marked with cryptic symbols"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.38",
+							"roll": {
+								"min": 67,
+								"max": 67
+							},
+							"text": "Numerous comings and goings"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.39",
+							"roll": {
+								"min": 68,
+								"max": 68
+							},
+							"text": "Oddly quiet"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.40",
+							"roll": {
+								"min": 69,
+								"max": 69
+							},
+							"text": "One building set apart"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.41",
+							"roll": {
+								"min": 70,
+								"max": 70
+							},
+							"text": "Partially abandoned"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.42",
+							"roll": {
+								"min": 71,
+								"max": 71
+							},
+							"text": "Prisoners or dead on display"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.43",
+							"roll": {
+								"min": 72,
+								"max": 72
+							},
+							"text": "Repairs underway"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.44",
+							"roll": {
+								"min": 73,
+								"max": 73
+							},
+							"text": "Scars of an attack or disaster"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.45",
+							"roll": {
+								"min": 74,
+								"max": 74
+							},
+							"text": "Shrouded by mist"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.46",
+							"roll": {
+								"min": 75,
+								"max": 75
+							},
+							"text": "Signs of sickness"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.47",
+							"roll": {
+								"min": 76,
+								"max": 76
+							},
+							"text": "Signs of an occupying force"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.48",
+							"roll": {
+								"min": 77,
+								"max": 77
+							},
+							"text": "Signs of unrest"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.49",
+							"roll": {
+								"min": 78,
+								"max": 78
+							},
+							"text": "Surrounded by fresh graves"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.50",
+							"roll": {
+								"min": 79,
+								"max": 79
+							},
+							"text": "Surrounded by lush terrain"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.51",
+							"roll": {
+								"min": 80,
+								"max": 80
+							},
+							"text": "Trophies of defeated foes"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.52",
+							"roll": {
+								"min": 81,
+								"max": 81
+							},
+							"text": "Lush gardens"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.53",
+							"roll": {
+								"min": 82,
+								"max": 82
+							},
+							"text": "Visited by large caravan or fleet"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.54",
+							"roll": {
+								"min": 83,
+								"max": 83
+							},
+							"text": "Widely dispersed structures"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.55",
+							"roll": {
+								"min": 84,
+								"max": 84
+							},
+							"text": "Alluring fragrances"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.56",
+							"roll": {
+								"min": 85,
+								"max": 85
+							},
+							"text": "Built from unusual materials"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.57",
+							"roll": {
+								"min": 86,
+								"max": 86
+							},
+							"text": "Busy marketplace"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.58",
+							"roll": {
+								"min": 87,
+								"max": 87
+							},
+							"text": "Festooned with bones and skulls"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.59",
+							"roll": {
+								"min": 88,
+								"max": 88
+							},
+							"text": "Flooded or waterlogged section"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.60",
+							"roll": {
+								"min": 89,
+								"max": 89
+							},
+							"text": "Foul stench"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.61",
+							"roll": {
+								"min": 90,
+								"max": 90
+							},
+							"text": "Partially destroyed by fire"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.62",
+							"roll": {
+								"min": 91,
+								"max": 91
+							},
+							"text": "Oddly-shaped structures"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.63",
+							"roll": {
+								"min": 92,
+								"max": 92
+							},
+							"text": "Old siege weapons left to rot"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.64",
+							"roll": {
+								"min": 93,
+								"max": 93
+							},
+							"text": "Signs of infestation or corruption"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.65",
+							"roll": {
+								"min": 94,
+								"max": 94
+							},
+							"text": "Solemn procession"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.66",
+							"roll": {
+								"min": 95,
+								"max": 95
+							},
+							"text": "Hung with countless torches"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.67",
+							"roll": {
+								"min": 96,
+								"max": 96
+							},
+							"text": "Eerie light or strange energies"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.68",
+							"roll": {
+								"min": 97,
+								"max": 97
+							},
+							"text": "Surrounded by blighted terrain"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.69",
+							"roll": {
+								"min": 98,
+								"max": 98
+							},
+							"text": "Unusual domesticated creatures"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.70",
+							"roll": {
+								"min": 99,
+								"max": 99
+							},
+							"text": "Eerie chanting or keening"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/first_look.71",
+							"roll": {
+								"min": 100,
+								"max": 100
+							},
+							"text": "Spectral manifestations"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 65,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"projects": {
+					"_id": "oracle_rollable:lodestar/settlement/projects",
+					"type": "oracle_rollable",
+					"name": "Projects",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.0",
+							"roll": {
+								"min": 1,
+								"max": 4
+							},
+							"text": "Farming"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.1",
+							"roll": {
+								"min": 5,
+								"max": 7
+							},
+							"text": "Celebration"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.2",
+							"roll": {
+								"min": 8,
+								"max": 10
+							},
+							"text": "Conquest"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.3",
+							"roll": {
+								"min": 11,
+								"max": 14
+							},
+							"text": "Religion"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.4",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Secrecy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.5",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Debauchery"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.6",
+							"roll": {
+								"min": 19,
+								"max": 21
+							},
+							"text": "Construction"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.7",
+							"roll": {
+								"min": 22,
+								"max": 23
+							},
+							"text": "Evacuation"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.8",
+							"roll": {
+								"min": 24,
+								"max": 25
+							},
+							"text": "Diplomacy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.9",
+							"roll": {
+								"min": 26,
+								"max": 29
+							},
+							"text": "Mysticism"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.10",
+							"roll": {
+								"min": 30,
+								"max": 31
+							},
+							"text": "History"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.11",
+							"roll": {
+								"min": 32,
+								"max": 33
+							},
+							"text": "Beast hunting"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.12",
+							"roll": {
+								"min": 34,
+								"max": 35
+							},
+							"text": "Scavenging"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.13",
+							"roll": {
+								"min": 36,
+								"max": 39
+							},
+							"text": "Brewing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.14",
+							"roll": {
+								"min": 40,
+								"max": 43
+							},
+							"text": "Defense"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.15",
+							"roll": {
+								"min": 44,
+								"max": 46
+							},
+							"text": "Exploration"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.16",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Patrolling"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.17",
+							"roll": {
+								"min": 49,
+								"max": 52
+							},
+							"text": "Mining"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.18",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Entertainment"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.19",
+							"roll": {
+								"min": 55,
+								"max": 58
+							},
+							"text": "Herding"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.20",
+							"roll": {
+								"min": 59,
+								"max": 62
+							},
+							"text": "Foraging"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.21",
+							"roll": {
+								"min": 63,
+								"max": 66
+							},
+							"text": "Trade"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.22",
+							"roll": {
+								"min": 67,
+								"max": 70
+							},
+							"text": "Forestry"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.23",
+							"roll": {
+								"min": 71,
+								"max": 74
+							},
+							"text": "Healing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.24",
+							"roll": {
+								"min": 75,
+								"max": 78
+							},
+							"text": "Hunting or fishing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.25",
+							"roll": {
+								"min": 79,
+								"max": 81
+							},
+							"text": "Hospitality"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.26",
+							"roll": {
+								"min": 82,
+								"max": 85
+							},
+							"text": "Craftwork"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.27",
+							"roll": {
+								"min": 86,
+								"max": 89
+							},
+							"text": "Smithing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.28",
+							"roll": {
+								"min": 90,
+								"max": 92
+							},
+							"text": "Raiding"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.29",
+							"roll": {
+								"min": 93,
+								"max": 94
+							},
+							"text": "Treasure hunting"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.30",
+							"roll": {
+								"min": 95,
+								"max": 96
+							},
+							"text": "Taming"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.31",
+							"roll": {
+								"min": 97,
+								"max": 98
+							},
+							"text": "Preservation"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/projects.32",
+							"roll": {
+								"min": 99,
+								"max": 100
+							},
+							"text": "Education"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 66,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"trouble": {
+					"_id": "oracle_rollable:lodestar/settlement/trouble",
+					"type": "oracle_rollable",
+					"name": "Settlement Trouble",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.0",
+							"roll": {
+								"min": 1,
+								"max": 2
+							},
+							"text": "Outsiders rejected"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.1",
+							"roll": {
+								"min": 3,
+								"max": 4
+							},
+							"text": "Dangerous discovery"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.2",
+							"roll": {
+								"min": 5,
+								"max": 6
+							},
+							"text": "Dreadful omens"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.3",
+							"roll": {
+								"min": 7,
+								"max": 8
+							},
+							"text": "Natural disaster"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.4",
+							"roll": {
+								"min": 9,
+								"max": 10
+							},
+							"text": "Old wounds reopened"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.5",
+							"roll": {
+								"min": 11,
+								"max": 12
+							},
+							"text": "Important object is lost"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.6",
+							"roll": {
+								"min": 13,
+								"max": 14
+							},
+							"text": "Someone is captured"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.7",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Mysterious phenomenon"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.8",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Revolt against a leader"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.9",
+							"roll": {
+								"min": 19,
+								"max": 20
+							},
+							"text": "Vengeful outcast"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.10",
+							"roll": {
+								"min": 21,
+								"max": 22
+							},
+							"text": "Rival settlement"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.11",
+							"roll": {
+								"min": 23,
+								"max": 24
+							},
+							"text": "Nature strikes back"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.12",
+							"roll": {
+								"min": 25,
+								"max": 26
+							},
+							"text": "Someone is missing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.13",
+							"roll": {
+								"min": 27,
+								"max": 28
+							},
+							"text": "Production halts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.14",
+							"roll": {
+								"min": 29,
+								"max": 30
+							},
+							"text": "Mysterious murders"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.15",
+							"roll": {
+								"min": 31,
+								"max": 32
+							},
+							"text": "Debt comes due"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.16",
+							"roll": {
+								"min": 33,
+								"max": 34
+							},
+							"text": "Unjust leadership"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.17",
+							"roll": {
+								"min": 35,
+								"max": 36
+							},
+							"text": "Disastrous accident"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.18",
+							"roll": {
+								"min": 37,
+								"max": 38
+							},
+							"text": "In league with the enemy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.19",
+							"roll": {
+								"min": 39,
+								"max": 40
+							},
+							"text": "Raiders prey on the weak"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.20",
+							"roll": {
+								"min": 41,
+								"max": 42
+							},
+							"text": "Cursed past"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.21",
+							"roll": {
+								"min": 43,
+								"max": 44
+							},
+							"text": "An innocent is accused"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.22",
+							"roll": {
+								"min": 45,
+								"max": 46
+							},
+							"text": "Corrupted by dark magic"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.23",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Isolated by brutal weather"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.24",
+							"roll": {
+								"min": 49,
+								"max": 50
+							},
+							"text": "Provisions are scarce"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.25",
+							"roll": {
+								"min": 51,
+								"max": 52
+							},
+							"text": "Sickness run amok"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.26",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Allies become enemies"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.27",
+							"roll": {
+								"min": 55,
+								"max": 56
+							},
+							"text": "Attack is imminent"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.28",
+							"roll": {
+								"min": 57,
+								"max": 58
+							},
+							"text": "Lost caravan"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.29",
+							"roll": {
+								"min": 59,
+								"max": 60
+							},
+							"text": "Dark secret revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.30",
+							"roll": {
+								"min": 61,
+								"max": 62
+							},
+							"text": "Urgent expedition"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.31",
+							"roll": {
+								"min": 63,
+								"max": 64
+							},
+							"text": "A leader falls"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.32",
+							"roll": {
+								"min": 65,
+								"max": 66
+							},
+							"text": "Families in conflict"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.33",
+							"roll": {
+								"min": 67,
+								"max": 68
+							},
+							"text": "Incompetent leadership"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.34",
+							"roll": {
+								"min": 69,
+								"max": 70
+							},
+							"text": "Reckless warmongering"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.35",
+							"roll": {
+								"min": 71,
+								"max": 72
+							},
+							"text": "Beast on the hunt"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.36",
+							"roll": {
+								"min": 73,
+								"max": 74
+							},
+							"text": "Betrayed from within"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.37",
+							"roll": {
+								"min": 75,
+								"max": 76
+							},
+							"text": "Broken truce"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.38",
+							"roll": {
+								"min": 77,
+								"max": 78
+							},
+							"text": "Wrathful haunt"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.39",
+							"roll": {
+								"min": 79,
+								"max": 80
+							},
+							"text": "Conflict with firstborn"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.40",
+							"roll": {
+								"min": 81,
+								"max": 82
+							},
+							"text": "Trade route blocked"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.41",
+							"roll": {
+								"min": 83,
+								"max": 84
+							},
+							"text": "Caught in the crossfire"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.42",
+							"roll": {
+								"min": 85,
+								"max": 86
+							},
+							"text": "Stranger causes discord"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.43",
+							"roll": {
+								"min": 87,
+								"max": 88
+							},
+							"text": "Important event threatened"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.44",
+							"roll": {
+								"min": 89,
+								"max": 90
+							},
+							"text": "Dangerous tradition"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/trouble.45",
+							"roll": {
+								"min": 91,
+								"max": 100
+							},
+							"text": "Roll twice",
+							"oracle_rolls": [
+								{
+									"oracle": null,
+									"dice": null,
+									"auto": true,
+									"duplicates": "reroll",
+									"number_of_rolls": 2
+								}
+							]
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 68,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"cultural_touchstones": {
+					"_id": "oracle_rollable:lodestar/settlement/cultural_touchstones",
+					"type": "oracle_rollable",
+					"name": "Cultural Touchstones",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.0",
+							"roll": {
+								"min": 1,
+								"max": 2
+							},
+							"text": "Austere styles"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.1",
+							"roll": {
+								"min": 3,
+								"max": 4
+							},
+							"text": "Prophecy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.2",
+							"roll": {
+								"min": 5,
+								"max": 6
+							},
+							"text": "Rites of adulthood"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.3",
+							"roll": {
+								"min": 7,
+								"max": 8
+							},
+							"text": "Feasting and merrymaking"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.4",
+							"roll": {
+								"min": 9,
+								"max": 10
+							},
+							"text": "Gambling"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.5",
+							"roll": {
+								"min": 11,
+								"max": 12
+							},
+							"text": "Code of pacifism"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.6",
+							"roll": {
+								"min": 13,
+								"max": 14
+							},
+							"text": "Suspicion of outsiders"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.7",
+							"roll": {
+								"min": 15,
+								"max": 16
+							},
+							"text": "Formal duels"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.8",
+							"roll": {
+								"min": 17,
+								"max": 18
+							},
+							"text": "Mysticism"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.9",
+							"roll": {
+								"min": 19,
+								"max": 20
+							},
+							"text": "Adherence to authority"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.10",
+							"roll": {
+								"min": 21,
+								"max": 22
+							},
+							"text": "Song and dance"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.11",
+							"roll": {
+								"min": 23,
+								"max": 24
+							},
+							"text": "Uncommon languages"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.12",
+							"roll": {
+								"min": 25,
+								"max": 26
+							},
+							"text": "Heavily-accented speech"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.13",
+							"roll": {
+								"min": 27,
+								"max": 28
+							},
+							"text": "Artistic expression"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.14",
+							"roll": {
+								"min": 29,
+								"max": 30
+							},
+							"text": "Distinctive armor"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.15",
+							"roll": {
+								"min": 31,
+								"max": 32
+							},
+							"text": "Bartering"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.16",
+							"roll": {
+								"min": 33,
+								"max": 34
+							},
+							"text": "Long mourning periods"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.17",
+							"roll": {
+								"min": 35,
+								"max": 36
+							},
+							"text": "Seasonal festivals"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.18",
+							"roll": {
+								"min": 37,
+								"max": 38
+							},
+							"text": "Blood feuds"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.19",
+							"roll": {
+								"min": 39,
+								"max": 40
+							},
+							"text": "Banishment of the disloyal"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.20",
+							"roll": {
+								"min": 41,
+								"max": 42
+							},
+							"text": "Rigid hierarchy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.21",
+							"roll": {
+								"min": 43,
+								"max": 44
+							},
+							"text": "Unbreakable vows"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.22",
+							"roll": {
+								"min": 45,
+								"max": 46
+							},
+							"text": "Communal resources"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.23",
+							"roll": {
+								"min": 47,
+								"max": 48
+							},
+							"text": "Spirituality"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.24",
+							"roll": {
+								"min": 49,
+								"max": 50
+							},
+							"text": "Strict laws"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.25",
+							"roll": {
+								"min": 51,
+								"max": 52
+							},
+							"text": "Respect of elders"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.26",
+							"roll": {
+								"min": 53,
+								"max": 54
+							},
+							"text": "Courtesy and hospitality"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.27",
+							"roll": {
+								"min": 55,
+								"max": 56
+							},
+							"text": "Body modifications or tattoos"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.28",
+							"roll": {
+								"min": 57,
+								"max": 58
+							},
+							"text": "Pilgrimages"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.29",
+							"roll": {
+								"min": 59,
+								"max": 60
+							},
+							"text": "Superstition"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.30",
+							"roll": {
+								"min": 61,
+								"max": 62
+							},
+							"text": "Ceremonies and rituals"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.31",
+							"roll": {
+								"min": 63,
+								"max": 64
+							},
+							"text": "Blood debts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.32",
+							"roll": {
+								"min": 65,
+								"max": 66
+							},
+							"text": "Familial clans"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.33",
+							"roll": {
+								"min": 67,
+								"max": 68
+							},
+							"text": "Isolationism and privacy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.34",
+							"roll": {
+								"min": 69,
+								"max": 70
+							},
+							"text": "Communal hunts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.35",
+							"roll": {
+								"min": 71,
+								"max": 72
+							},
+							"text": "Competitive tournaments"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.36",
+							"roll": {
+								"min": 73,
+								"max": 74
+							},
+							"text": "Code of honor"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.37",
+							"roll": {
+								"min": 75,
+								"max": 76
+							},
+							"text": "Storytelling"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.38",
+							"roll": {
+								"min": 77,
+								"max": 78
+							},
+							"text": "Conquest and battle prowess"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.39",
+							"roll": {
+								"min": 79,
+								"max": 80
+							},
+							"text": "Martyred heroes"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.40",
+							"roll": {
+								"min": 81,
+								"max": 82
+							},
+							"text": "Sacred texts"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.41",
+							"roll": {
+								"min": 83,
+								"max": 84
+							},
+							"text": "Rites of courtship"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.42",
+							"roll": {
+								"min": 85,
+								"max": 86
+							},
+							"text": "Bonded creatures"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.43",
+							"roll": {
+								"min": 87,
+								"max": 88
+							},
+							"text": "Signature weapon"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.44",
+							"roll": {
+								"min": 89,
+								"max": 90
+							},
+							"text": "Hidden identities"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.45",
+							"roll": {
+								"min": 91,
+								"max": 92
+							},
+							"text": "Gift-giving"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.46",
+							"roll": {
+								"min": 93,
+								"max": 94
+							},
+							"text": "Animal or nature motifs"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.47",
+							"roll": {
+								"min": 95,
+								"max": 96
+							},
+							"text": "Independence from authority"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.48",
+							"roll": {
+								"min": 97,
+								"max": 98
+							},
+							"text": "Unusual death rites"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/settlement/cultural_touchstones.49",
+							"roll": {
+								"min": 99,
+								"max": 100
+							},
+							"text": "Elaborate styles"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 67,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {
+				"quick_name": {
+					"_id": "oracle_collection:lodestar/settlement/quick_name",
+					"type": "oracle_collection",
+					"name": "Quick Settlement Name Generator",
+					"oracle_type": "table_shared_rolls",
+					"summary": "Roll once for the prefix and once for the suffix, taking your pick of choices in that row.",
+					"contents": {
+						"prefix_a": {
+							"_id": "oracle_rollable:lodestar/settlement/quick_name/prefix_a",
+							"type": "oracle_rollable",
+							"name": "Prefix A",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Lost-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Gloom-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Night-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Stone-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Bright-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Dusk-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "White-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Grim-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "Wrath-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Sword-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.10",
+									"roll": {
+										"min": 41,
+										"max": 43
+									},
+									"text": "Wyrm-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.11",
+									"roll": {
+										"min": 44,
+										"max": 46
+									},
+									"text": "Shield-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.12",
+									"roll": {
+										"min": 47,
+										"max": 49
+									},
+									"text": "Keld-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.13",
+									"roll": {
+										"min": 50,
+										"max": 52
+									},
+									"text": "Low-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.14",
+									"roll": {
+										"min": 53,
+										"max": 55
+									},
+									"text": "Troll-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.15",
+									"roll": {
+										"min": 56,
+										"max": 58
+									},
+									"text": "New-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.16",
+									"roll": {
+										"min": 59,
+										"max": 61
+									},
+									"text": "Mead-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.17",
+									"roll": {
+										"min": 62,
+										"max": 64
+									},
+									"text": "Drift-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.18",
+									"roll": {
+										"min": 65,
+										"max": 67
+									},
+									"text": "Wolf-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.19",
+									"roll": {
+										"min": 68,
+										"max": 70
+									},
+									"text": "Long-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.20",
+									"roll": {
+										"min": 71,
+										"max": 73
+									},
+									"text": "Iron-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.21",
+									"roll": {
+										"min": 74,
+										"max": 76
+									},
+									"text": "Shale-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.22",
+									"roll": {
+										"min": 77,
+										"max": 79
+									},
+									"text": "Woad-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.23",
+									"roll": {
+										"min": 80,
+										"max": 82
+									},
+									"text": "Rock-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.24",
+									"roll": {
+										"min": 83,
+										"max": 85
+									},
+									"text": "Murk-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.25",
+									"roll": {
+										"min": 86,
+										"max": 88
+									},
+									"text": "Moon-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.26",
+									"roll": {
+										"min": 89,
+										"max": 91
+									},
+									"text": "Fire-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.27",
+									"roll": {
+										"min": 92,
+										"max": 94
+									},
+									"text": "Green-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.28",
+									"roll": {
+										"min": 95,
+										"max": 97
+									},
+									"text": "Gold-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_a.29",
+									"roll": {
+										"min": 98,
+										"max": 100
+									},
+									"text": "Mourn-"
+								}
+							]
+						},
+						"suffix_a": {
+							"_id": "oracle_rollable:lodestar/settlement/quick_name/suffix_a",
+							"type": "oracle_rollable",
+							"name": "Suffix A",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "-grove"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "-haven"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "-bourne"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "-bridge"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "-peak"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "-shard"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "-glade"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "-hold"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "-stead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "-crest"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.10",
+									"roll": {
+										"min": 41,
+										"max": 43
+									},
+									"text": "-rock"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.11",
+									"roll": {
+										"min": 44,
+										"max": 46
+									},
+									"text": "-fall"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.12",
+									"roll": {
+										"min": 47,
+										"max": 49
+									},
+									"text": "-mark"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.13",
+									"roll": {
+										"min": 50,
+										"max": 52
+									},
+									"text": "-fen"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.14",
+									"roll": {
+										"min": 53,
+										"max": 55
+									},
+									"text": "-barrow"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.15",
+									"roll": {
+										"min": 56,
+										"max": 58
+									},
+									"text": "-ford"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.16",
+									"roll": {
+										"min": 59,
+										"max": 61
+									},
+									"text": "-wood"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.17",
+									"roll": {
+										"min": 62,
+										"max": 64
+									},
+									"text": "-run"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.18",
+									"roll": {
+										"min": 65,
+										"max": 67
+									},
+									"text": "-croft"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.19",
+									"roll": {
+										"min": 68,
+										"max": 70
+									},
+									"text": "-knoll"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.20",
+									"roll": {
+										"min": 71,
+										"max": 73
+									},
+									"text": "-march"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.21",
+									"roll": {
+										"min": 74,
+										"max": 76
+									},
+									"text": "-reach"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.22",
+									"roll": {
+										"min": 77,
+										"max": 79
+									},
+									"text": "-bluff"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.23",
+									"roll": {
+										"min": 80,
+										"max": 82
+									},
+									"text": "-holt"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.24",
+									"roll": {
+										"min": 83,
+										"max": 85
+									},
+									"text": "-home"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.25",
+									"roll": {
+										"min": 86,
+										"max": 88
+									},
+									"text": "-hope"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.26",
+									"roll": {
+										"min": 89,
+										"max": 91
+									},
+									"text": "-wark"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.27",
+									"roll": {
+										"min": 92,
+										"max": 94
+									},
+									"text": "-burrow"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.28",
+									"roll": {
+										"min": 95,
+										"max": 97
+									},
+									"text": "-glen"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_a.29",
+									"roll": {
+										"min": 98,
+										"max": 100
+									},
+									"text": "-mist"
+								}
+							]
+						},
+						"prefix_b": {
+							"_id": "oracle_rollable:lodestar/settlement/quick_name/prefix_b",
+							"type": "oracle_rollable",
+							"name": "Prefix B",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "Forge-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "Fallow-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "Red-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "Wyrd-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "Bleak-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "Wood-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "Gray-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "Draug-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "High-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "Raven-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.10",
+									"roll": {
+										"min": 41,
+										"max": 43
+									},
+									"text": "Deep-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.11",
+									"roll": {
+										"min": 44,
+										"max": 46
+									},
+									"text": "Tide-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.12",
+									"roll": {
+										"min": 47,
+										"max": 49
+									},
+									"text": "Ash-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.13",
+									"roll": {
+										"min": 50,
+										"max": 52
+									},
+									"text": "Frost-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.14",
+									"roll": {
+										"min": 53,
+										"max": 55
+									},
+									"text": "Dark-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.15",
+									"roll": {
+										"min": 56,
+										"max": 58
+									},
+									"text": "Storm-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.16",
+									"roll": {
+										"min": 59,
+										"max": 61
+									},
+									"text": "Ember-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.17",
+									"roll": {
+										"min": 62,
+										"max": 64
+									},
+									"text": "Flint-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.18",
+									"roll": {
+										"min": 65,
+										"max": 67
+									},
+									"text": "Thorn-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.19",
+									"roll": {
+										"min": 68,
+										"max": 70
+									},
+									"text": "Axe-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.20",
+									"roll": {
+										"min": 71,
+										"max": 73
+									},
+									"text": "Black-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.21",
+									"roll": {
+										"min": 74,
+										"max": 76
+									},
+									"text": "Nettle-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.22",
+									"roll": {
+										"min": 77,
+										"max": 79
+									},
+									"text": "Broad-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.23",
+									"roll": {
+										"min": 80,
+										"max": 82
+									},
+									"text": "Hearth-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.24",
+									"roll": {
+										"min": 83,
+										"max": 85
+									},
+									"text": "Ice-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.25",
+									"roll": {
+										"min": 86,
+										"max": 88
+									},
+									"text": "Bitter-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.26",
+									"roll": {
+										"min": 89,
+										"max": 91
+									},
+									"text": "Great-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.27",
+									"roll": {
+										"min": 92,
+										"max": 94
+									},
+									"text": "Bear-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.28",
+									"roll": {
+										"min": 95,
+										"max": 97
+									},
+									"text": "Skarn-"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/prefix_b.29",
+									"roll": {
+										"min": 98,
+										"max": 100
+									},
+									"text": "Shade-"
+								}
+							]
+						},
+						"suffix_b": {
+							"_id": "oracle_rollable:lodestar/settlement/quick_name/suffix_b",
+							"type": "oracle_rollable",
+							"name": "Suffix B",
+							"oracle_type": "column_text",
+							"dice": "1d100",
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.0",
+									"roll": {
+										"min": 1,
+										"max": 4
+									},
+									"text": "-break"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.1",
+									"roll": {
+										"min": 5,
+										"max": 8
+									},
+									"text": "-mire"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.2",
+									"roll": {
+										"min": 9,
+										"max": 12
+									},
+									"text": "-brook"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.3",
+									"roll": {
+										"min": 13,
+										"max": 16
+									},
+									"text": "-wick"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.4",
+									"roll": {
+										"min": 17,
+										"max": 20
+									},
+									"text": "-harrow"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.5",
+									"roll": {
+										"min": 21,
+										"max": 24
+									},
+									"text": "-hall"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.6",
+									"roll": {
+										"min": 25,
+										"max": 28
+									},
+									"text": "-watch"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.7",
+									"roll": {
+										"min": 29,
+										"max": 32
+									},
+									"text": "-well"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.8",
+									"roll": {
+										"min": 33,
+										"max": 36
+									},
+									"text": "-gate"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.9",
+									"roll": {
+										"min": 37,
+										"max": 40
+									},
+									"text": "-mount"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.10",
+									"roll": {
+										"min": 41,
+										"max": 43
+									},
+									"text": "-ridge"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.11",
+									"roll": {
+										"min": 44,
+										"max": 46
+									},
+									"text": "-ward"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.12",
+									"roll": {
+										"min": 47,
+										"max": 49
+									},
+									"text": "-mere"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.13",
+									"roll": {
+										"min": 50,
+										"max": 52
+									},
+									"text": "-field"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.14",
+									"roll": {
+										"min": 53,
+										"max": 55
+									},
+									"text": "-river"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.15",
+									"roll": {
+										"min": 56,
+										"max": 58
+									},
+									"text": "-hill"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.16",
+									"roll": {
+										"min": 59,
+										"max": 61
+									},
+									"text": "-tarn"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.17",
+									"roll": {
+										"min": 62,
+										"max": 64
+									},
+									"text": "-spire"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.18",
+									"roll": {
+										"min": 65,
+										"max": 67
+									},
+									"text": "-scar"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.19",
+									"roll": {
+										"min": 68,
+										"max": 70
+									},
+									"text": "-roost"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.20",
+									"roll": {
+										"min": 71,
+										"max": 73
+									},
+									"text": "-shade"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.21",
+									"roll": {
+										"min": 74,
+										"max": 76
+									},
+									"text": "-stone"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.22",
+									"roll": {
+										"min": 77,
+										"max": 79
+									},
+									"text": "-nest"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.23",
+									"roll": {
+										"min": 80,
+										"max": 82
+									},
+									"text": "-pass"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.24",
+									"roll": {
+										"min": 83,
+										"max": 85
+									},
+									"text": "-point"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.25",
+									"roll": {
+										"min": 86,
+										"max": 88
+									},
+									"text": "-vault"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.26",
+									"roll": {
+										"min": 89,
+										"max": 91
+									},
+									"text": "-cairn"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.27",
+									"roll": {
+										"min": 92,
+										"max": 94
+									},
+									"text": "-hollow"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.28",
+									"roll": {
+										"min": 95,
+										"max": 97
+									},
+									"text": "-moor"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/quick_name/suffix_b.29",
+									"roll": {
+										"min": 98,
+										"max": 100
+									},
+									"text": "-crag"
+								}
+							]
+						}
+					},
+					"column_labels": {
+						"roll": "Roll"
+					},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 69,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"type": {
+					"_id": "oracle_collection:lodestar/settlement/type",
+					"type": "oracle_collection",
+					"name": "Type",
+					"oracle_type": "tables",
+					"summary": "When using this oracle to reveal the scale and purpose of a settlement, choose whether the community is located in settled lands, boundary lands, or remote lands.",
+					"contents": {
+						"settled_lands": {
+							"_id": "oracle_rollable:lodestar/settlement/type/settled_lands",
+							"type": "oracle_rollable",
+							"name": "Settled Lands",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.0",
+									"roll": {
+										"min": 1,
+										"max": 15
+									},
+									"text": "Stead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.1",
+									"roll": {
+										"min": 16,
+										"max": 25
+									},
+									"text": "Camp"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.2",
+									"roll": {
+										"min": 26,
+										"max": 30
+									},
+									"text": "Outpost"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.3",
+									"roll": {
+										"min": 31,
+										"max": 55
+									},
+									"text": "Hamlet"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.4",
+									"roll": {
+										"min": 56,
+										"max": 85
+									},
+									"text": "Village"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/settled_lands.5",
+									"roll": {
+										"min": 86,
+										"max": 100
+									},
+									"text": "Hold"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 64,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"boundary_lands": {
+							"_id": "oracle_rollable:lodestar/settlement/type/boundary_lands",
+							"type": "oracle_rollable",
+							"name": "Boundary Lands",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.0",
+									"roll": {
+										"min": 1,
+										"max": 20
+									},
+									"text": "Stead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.1",
+									"roll": {
+										"min": 21,
+										"max": 35
+									},
+									"text": "Camp"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.2",
+									"roll": {
+										"min": 36,
+										"max": 60
+									},
+									"text": "Outpost"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.3",
+									"roll": {
+										"min": 61,
+										"max": 80
+									},
+									"text": "Hamlet"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.4",
+									"roll": {
+										"min": 81,
+										"max": 95
+									},
+									"text": "Village"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/boundary_lands.5",
+									"roll": {
+										"min": 96,
+										"max": 100
+									},
+									"text": "Hold"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 64,
+								"url": "https://ironswornrpg.com"
+							}
+						},
+						"remote_lands": {
+							"_id": "oracle_rollable:lodestar/settlement/type/remote_lands",
+							"type": "oracle_rollable",
+							"name": "Remote Lands",
+							"oracle_type": "table_text",
+							"dice": "1d100",
+							"column_labels": {
+								"roll": "Roll",
+								"text": "Result"
+							},
+							"rows": [
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.0",
+									"roll": {
+										"min": 1,
+										"max": 25
+									},
+									"text": "Stead"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.1",
+									"roll": {
+										"min": 26,
+										"max": 50
+									},
+									"text": "Camp"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.2",
+									"roll": {
+										"min": 51,
+										"max": 75
+									},
+									"text": "Outpost"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.3",
+									"roll": {
+										"min": 76,
+										"max": 90
+									},
+									"text": "Hamlet"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.4",
+									"roll": {
+										"min": 91,
+										"max": 98
+									},
+									"text": "Village"
+								},
+								{
+									"_id": "oracle_rollable.row:lodestar/settlement/type/remote_lands.5",
+									"roll": {
+										"min": 99,
+										"max": 100
+									},
+									"text": "Hold"
+								}
+							],
+							"_source": {
+								"title": "Ironsworn: Lodestar",
+								"authors": [
+									{
+										"name": "Shawn Tomkin"
+									}
+								],
+								"date": "2025-05-01",
+								"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+								"page": 64,
+								"url": "https://ironswornrpg.com"
+							}
+						}
+					},
+					"collections": {},
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 64,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 64,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"story": {
+			"_id": "oracle_collection:lodestar/story",
+			"type": "oracle_collection",
+			"name": "Story Oracles",
+			"oracle_type": "tables",
+			"contents": {
+				"clue": {
+					"_id": "oracle_rollable:lodestar/story/clue",
+					"type": "oracle_rollable",
+					"name": "Clue",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "When you investigate a mystery, you might uncover clues in the form of messages, rumors, eyewitness reports, supernatural revelations, or physical evidence. Use this oracle to help reveal what this evidence connects to or implicates.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.0",
+							"roll": {
+								"min": 1,
+								"max": 3
+							},
+							"text": "Affirms a previously understood fact or clue"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.1",
+							"roll": {
+								"min": 4,
+								"max": 6
+							},
+							"text": "Connects to a known rumor or scandal"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.2",
+							"roll": {
+								"min": 7,
+								"max": 9
+							},
+							"text": "Connects to a previously unrelated mystery or quest"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.3",
+							"roll": {
+								"min": 10,
+								"max": 12
+							},
+							"text": "Connects to your own expertise or interests"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.4",
+							"roll": {
+								"min": 13,
+								"max": 15
+							},
+							"text": "Contradicts a previously understood fact or clue"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.5",
+							"roll": {
+								"min": 16,
+								"max": 18
+							},
+							"text": "Evokes a personal memory"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.6",
+							"roll": {
+								"min": 19,
+								"max": 21
+							},
+							"text": "Evokes a legend or prophecy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.7",
+							"roll": {
+								"min": 22,
+								"max": 24
+							},
+							"text": "Evokes a dream or vision"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.8",
+							"roll": {
+								"min": 25,
+								"max": 27
+							},
+							"text": "Involves a hidden or mysterious community"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.9",
+							"roll": {
+								"min": 28,
+								"max": 30
+							},
+							"text": "Involves a hidden or mysterious person"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.10",
+							"roll": {
+								"min": 31,
+								"max": 33
+							},
+							"text": "Involves a nonhuman being or entity"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.11",
+							"roll": {
+								"min": 34,
+								"max": 36
+							},
+							"text": "Involves a creature"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.12",
+							"roll": {
+								"min": 37,
+								"max": 39
+							},
+							"text": "Involves an artifact or precious object"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.13",
+							"roll": {
+								"min": 40,
+								"max": 42
+							},
+							"text": "Involves a personal item"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.14",
+							"roll": {
+								"min": 43,
+								"max": 45
+							},
+							"text": "Involves a weapon"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.15",
+							"roll": {
+								"min": 46,
+								"max": 48
+							},
+							"text": "Involves a valuable resource"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.16",
+							"roll": {
+								"min": 49,
+								"max": 51
+							},
+							"text": "Involves a notable community or faction"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.17",
+							"roll": {
+								"min": 52,
+								"max": 54
+							},
+							"text": "Involves a leader or notable person"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.18",
+							"roll": {
+								"min": 55,
+								"max": 57
+							},
+							"text": "Involves a person or community from your background"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.19",
+							"roll": {
+								"min": 58,
+								"max": 60
+							},
+							"text": "Involves an enemy or rival"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.20",
+							"roll": {
+								"min": 61,
+								"max": 63
+							},
+							"text": "Involves someone you trust"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.21",
+							"roll": {
+								"min": 64,
+								"max": 65
+							},
+							"text": "Involves a mystic power or ritual"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.22",
+							"roll": {
+								"min": 66,
+								"max": 68
+							},
+							"text": "Involves an ailment or affliction"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.23",
+							"roll": {
+								"min": 69,
+								"max": 71
+							},
+							"text": "Involves a religion or belief"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.24",
+							"roll": {
+								"min": 72,
+								"max": 74
+							},
+							"text": "Involves a promise or debt"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.25",
+							"roll": {
+								"min": 75,
+								"max": 77
+							},
+							"text": "Leads to a nearby or familiar place"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.26",
+							"roll": {
+								"min": 78,
+								"max": 80
+							},
+							"text": "Leads to an ancient or ruined place"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.27",
+							"roll": {
+								"min": 81,
+								"max": 83
+							},
+							"text": "Leads to a settled place"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.28",
+							"roll": {
+								"min": 84,
+								"max": 86
+							},
+							"text": "Leads to a remote or wild place"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.29",
+							"roll": {
+								"min": 87,
+								"max": 89
+							},
+							"text": "Leads to a notable landmark"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.30",
+							"roll": {
+								"min": 90,
+								"max": 91
+							},
+							"text": "Leads to a mystical or unearthly place"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.31",
+							"roll": {
+								"min": 92,
+								"max": 94
+							},
+							"text": "Suggests a history of similar incidents"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.32",
+							"roll": {
+								"min": 95,
+								"max": 97
+							},
+							"text": "Suggests a looming event or deadline"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/clue.33",
+							"roll": {
+								"min": 98,
+								"max": 100
+							},
+							"text": "Suggests an imposter or deception"
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 93,
+						"url": "https://ironswornrpg.com"
+					}
+				},
+				"plot_twist": {
+					"_id": "oracle_rollable:lodestar/story/plot_twist",
+					"type": "oracle_rollable",
+					"name": "Major Plot Twist",
+					"oracle_type": "table_text",
+					"dice": "1d100",
+					"summary": "Use this oracle to introduce a narrative surprise or revelation. Most of these results have a negative implication, and can be used to resolve a match at a crucial moment in your story. In particular, this is an effective tool to leverage when you make a move with matched 10's on the challenge dice.",
+					"column_labels": {
+						"roll": "Roll",
+						"text": "Result"
+					},
+					"rows": [
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.0",
+							"roll": {
+								"min": 1,
+								"max": 5
+							},
+							"text": "It was all a diversion"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.1",
+							"roll": {
+								"min": 6,
+								"max": 10
+							},
+							"text": "A dark secret is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.2",
+							"roll": {
+								"min": 11,
+								"max": 15
+							},
+							"text": "A trap is sprung"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.3",
+							"roll": {
+								"min": 16,
+								"max": 20
+							},
+							"text": "An assumption is revealed to be false"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.4",
+							"roll": {
+								"min": 21,
+								"max": 25
+							},
+							"text": "A secret alliance is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.5",
+							"roll": {
+								"min": 26,
+								"max": 30
+							},
+							"text": "Your actions benefit an enemy"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.6",
+							"roll": {
+								"min": 31,
+								"max": 35
+							},
+							"text": "Someone returns unexpectedly"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.7",
+							"roll": {
+								"min": 36,
+								"max": 40
+							},
+							"text": "A more dangerous foe is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.8",
+							"roll": {
+								"min": 41,
+								"max": 45
+							},
+							"text": "You and an enemy share a common goal"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.9",
+							"roll": {
+								"min": 46,
+								"max": 50
+							},
+							"text": "A true identity is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.10",
+							"roll": {
+								"min": 51,
+								"max": 55
+							},
+							"text": "You are betrayed by someone who was trusted"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.11",
+							"roll": {
+								"min": 56,
+								"max": 60
+							},
+							"text": "You are too late"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.12",
+							"roll": {
+								"min": 61,
+								"max": 65
+							},
+							"text": "The true enemy is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.13",
+							"roll": {
+								"min": 66,
+								"max": 70
+							},
+							"text": "The enemy gains new allies"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.14",
+							"roll": {
+								"min": 71,
+								"max": 75
+							},
+							"text": "A new danger appears"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.15",
+							"roll": {
+								"min": 76,
+								"max": 80
+							},
+							"text": "Someone or something goes missing"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.16",
+							"roll": {
+								"min": 81,
+								"max": 85
+							},
+							"text": "The truth of a relationship is revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.17",
+							"roll": {
+								"min": 86,
+								"max": 90
+							},
+							"text": "Two seemingly unrelated situations are shown to be connected"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.18",
+							"roll": {
+								"min": 91,
+								"max": 95
+							},
+							"text": "Unexpected powers or abilities are revealed"
+						},
+						{
+							"_id": "oracle_rollable.row:lodestar/story/plot_twist.19",
+							"roll": {
+								"min": 96,
+								"max": 100
+							},
+							"text": "Roll twice; if they are the same result, make it worse",
+							"oracle_rolls": [
+								{
+									"oracle": null,
+									"dice": null,
+									"auto": true,
+									"duplicates": "make_it_worse",
+									"number_of_rolls": 2
+								}
+							]
+						}
+					],
+					"_source": {
+						"title": "Ironsworn: Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 95,
+						"url": "https://ironswornrpg.com"
+					}
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn: Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 92,
+				"url": "https://ironswornrpg.com"
+			}
+		}
+	},
+	"assets": {},
+	"atlas": {},
+	"moves": {
+		"journey": {
+			"_id": "move_category:lodestar/journey",
+			"type": "move_category",
+			"name": "Journey Moves",
+			"enhances": [
+				"move_category:classic/adventure"
+			],
+			"summary": "Journey moves are used as you travel across the Ironlands.",
+			"contents": {
+				"follow_a_path": {
+					"_id": "move:lodestar/journey/follow_a_path",
+					"type": "move",
+					"name": "Follow a Path",
+					"roll_type": "action_roll",
+					"trigger": {
+						"conditions": [
+							{
+								"_id": "move.condition:lodestar/journey/follow_a_path.0",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "condition_meter",
+										"condition_meter": "supply"
+									}
+								]
+							}
+						],
+						"text": "When you journey along a known route, and one day blends into the next..."
+					},
+					"text": "When __you journey along a known route, and one day blends into the next__, roll +supply.\n\nOn a __strong hit__, you reach your destination and the situation favors you. Take +1 momentum.\n\nOn a __weak hit__, you complete the journey, but face a cost or complication. Choose one or more.\n\n  * You took longer than expected.\n  * You pressed on through pain, sickness, or weariness: [Endure Harm](datasworn:move:classic/suffer/endure_harm).\n  * You suffered under the burden of foul weather, worries, or fearful locations: [Endure Stress](datasworn:move:classic/suffer/endure_stress).\n  * You wasted resources.\n  * You face a complication or hazard at the destination. Envision what you find ([Ask the Oracle](datasworn:move:classic/fate/ask_the_oracle) if unsure).\n\nOn a __miss__, you are waylaid by a dire threat and must [Pay the Price](datasworn:move:classic/fate/pay_the_price). If you overcome this obstacle, you may push on safely to your destination.",
+					"outcomes": {
+						"strong_hit": {
+							"_id": "move.outcome:lodestar/journey/follow_a_path.strong_hit",
+							"text": "On a __strong hit__, you reach your destination and the situation favors you. Take +1 momentum."
+						},
+						"weak_hit": {
+							"_id": "move.outcome:lodestar/journey/follow_a_path.weak_hit",
+							"text": "On a __weak hit__, you complete the journey, but face a cost or complication. Choose one or more.\n\n  * You took longer than expected.\n  * You pressed on through pain, sickness, or weariness: [Endure Harm](datasworn:move:classic/suffer/endure_harm).\n  * You suffered under the burden of foul weather, worries, or fearful locations: [Endure Stress](datasworn:move:classic/suffer/endure_stress).\n  * You wasted resources.\n  * You face a complication or hazard at the destination. Envision what you find ([Ask the Oracle](datasworn:move:classic/fate/ask_the_oracle) if unsure)."
+						},
+						"miss": {
+							"_id": "move.outcome:lodestar/journey/follow_a_path.miss",
+							"text": "On a __miss__, you are waylaid by a dire threat and must [Pay the Price](datasworn:move:classic/fate/pay_the_price). If you overcome this obstacle, you may push on safely to your destination."
+						}
+					},
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 10,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": true
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 10,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"adventure": {
+			"_id": "move_category:lodestar/adventure",
+			"type": "move_category",
+			"name": "Adventure Moves",
+			"enhances": [
+				"move_category:classic/adventure"
+			],
+			"contents": {
+				"face_danger": {
+					"_id": "move:lodestar/adventure/face_danger",
+					"type": "move",
+					"name": "Face Danger",
+					"roll_type": "action_roll",
+					"replaces": [
+						"move:classic/adventure/face_danger"
+					],
+					"trigger": {
+						"conditions": [
+							{
+								"_id": "move.condition:lodestar/adventure/face_danger.0",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "edge"
+									}
+								],
+								"text": "With speed, agility, or precision"
+							},
+							{
+								"_id": "move.condition:lodestar/adventure/face_danger.1",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "heart"
+									}
+								],
+								"text": "With charm, loyalty, or courage"
+							},
+							{
+								"_id": "move.condition:lodestar/adventure/face_danger.2",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "iron"
+									}
+								],
+								"text": "With aggressive action, forceful defense, strength, or endurance"
+							},
+							{
+								"_id": "move.condition:lodestar/adventure/face_danger.3",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "shadow"
+									}
+								],
+								"text": "With deception, stealth, or trickery"
+							},
+							{
+								"_id": "move.condition:lodestar/adventure/face_danger.4",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "wits"
+									}
+								],
+								"text": "With expertise, insight, or observation"
+							}
+						],
+						"text": "When you attempt something risky or react to an imminent threat..."
+					},
+					"text": "When __you attempt something risky or react to an imminent threat__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, you are successful. Take +1 momentum.\n\nOn a __weak hit__, you succeed, but face a troublesome cost. Choose one.\n\n  * You are delayed, lose advantage, or face a new danger: Suffer -1 momentum.\n  * You are tired or hurt: [Endure Harm](datasworn:move:classic/suffer/endure_harm) (1 harm).\n  * You are dispirited or afraid: [Endure Stress](datasworn:move:classic/suffer/endure_stress) (1 stress).\n  * You sacrifice resources: Suffer -1 supply.\n\nOn a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
+					"outcomes": {
+						"strong_hit": {
+							"_id": "move.outcome:lodestar/adventure/face_danger.strong_hit",
+							"text": "On a __strong hit__, you are successful. Take +1 momentum."
+						},
+						"weak_hit": {
+							"_id": "move.outcome:lodestar/adventure/face_danger.weak_hit",
+							"text": "On a __weak hit__, you succeed, but face a troublesome cost. Choose one.\n\n  * You are delayed, lose advantage, or face a new danger: Suffer -1 momentum.\n  * You are tired or hurt: [Endure Harm](datasworn:move:classic/suffer/endure_harm) (1 harm).\n  * You are dispirited or afraid: [Endure Stress](datasworn:move:classic/suffer/endure_stress) (1 stress).\n  * You sacrifice resources: Suffer -1 supply."
+						},
+						"miss": {
+							"_id": "move.outcome:lodestar/adventure/face_danger.miss",
+							"text": "On a __miss__, you fail, or a momentary success is undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
+						}
+					},
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 8,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": true
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 8,
+				"url": "https://ironswornrpg.com"
+			}
+		},
+		"scene_challenge": {
+			"_id": "move_category:lodestar/scene_challenge",
+			"type": "move_category",
+			"name": "Scene Challenge Moves",
+			"summary": "A scene challenge is an optional approach you can use to resolve an extended challenge against an obstacle or NPCs.",
+			"contents": {
+				"begin_the_scene": {
+					"_id": "move:lodestar/scene_challenge/begin_the_scene",
+					"type": "move",
+					"name": "Begin the Scene",
+					"roll_type": "no_roll",
+					"trigger": {
+						"conditions": [],
+						"text": "When you face an extended or complex challenge..."
+					},
+					"text": "When __you face an extended or complex challenge__, name your objective and choose a rank as appropriate to the situation.\n\n  * You have a clear advantage: Troublesome\n  * You are ready to act: Dangerous\n  * You are unprepared or outmatched: Formidable\n\nThen, activate a four-segment countdown track and [Face Danger](datasworn:move:lodestar/scene_challenge/face_danger) or [Secure an Advantage](datasworn:move:lodestar/scene_challenge/secure_an_advantage) to take action.",
+					"outcomes": null,
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 11,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": false
+				},
+				"face_danger": {
+					"_id": "move:lodestar/scene_challenge/face_danger",
+					"type": "move",
+					"name": "Face Danger (Scene Challenge)",
+					"roll_type": "action_roll",
+					"trigger": {
+						"conditions": [
+							{
+								"_id": "move.condition:lodestar/scene_challenge/face_danger.0",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "edge"
+									}
+								],
+								"text": "With speed, mobility, or agility"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/face_danger.1",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "heart"
+									}
+								],
+								"text": "With charm, loyalty, or courage"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/face_danger.2",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "iron"
+									}
+								],
+								"text": "With aggressive action, forceful defense, strength, or endurance"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/face_danger.3",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "shadow"
+									}
+								],
+								"text": "With deception, stealth, or trickery"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/face_danger.4",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "wits"
+									}
+								],
+								"text": "With expertise, insight, or observation"
+							}
+						],
+						"text": "When you attempt something risky or react to an imminent threat within a scene challenge..."
+					},
+					"text": "When __you attempt something risky or react to an imminent threat within a scene challenge__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, you are successful and mark progress. On a __strong hit with a match__, mark progress twice.\n\nOn a __weak hit__, you are successful and mark progress, but also encounter a complication or setback. Envision what occurs and mark a countdown segment.\n\nOn a __miss__, you fail, or a momentary success is undermined by a dramatic turn of events. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
+					"outcomes": {
+						"strong_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/face_danger.strong_hit",
+							"text": "On a __strong hit__, you are successful and mark progress. On a __strong hit with a match__, mark progress twice."
+						},
+						"weak_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/face_danger.weak_hit",
+							"text": "On a __weak hit__, you are successful and mark progress, but also encounter a complication or setback. Envision what occurs and mark a countdown segment."
+						},
+						"miss": {
+							"_id": "move.outcome:lodestar/scene_challenge/face_danger.miss",
+							"text": "On a __miss__, you fail, or a momentary success is undermined by a dramatic turn of events. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
+						}
+					},
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 11,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": true
+				},
+				"secure_an_advantage": {
+					"_id": "move:lodestar/scene_challenge/secure_an_advantage",
+					"type": "move",
+					"name": "Secure an Advantage (Scene Challenge)",
+					"roll_type": "action_roll",
+					"trigger": {
+						"conditions": [
+							{
+								"_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.0",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "edge"
+									}
+								],
+								"text": "With speed, agility, or precision"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.1",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "heart"
+									}
+								],
+								"text": "With charm, loyalty, or courage"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.2",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "iron"
+									}
+								],
+								"text": "With aggressive action, forceful defense, strength, or endurance"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.3",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "shadow"
+									}
+								],
+								"text": "With deception, stealth, or trickery"
+							},
+							{
+								"_id": "move.condition:lodestar/scene_challenge/secure_an_advantage.4",
+								"method": "player_choice",
+								"roll_options": [
+									{
+										"using": "stat",
+										"stat": "wits"
+									}
+								],
+								"text": "With expertise, insight, or observation"
+							}
+						],
+						"text": "When you assess a situation, make preparations, or attempt to gain leverage within a scene challenge..."
+					},
+					"text": "When __you assess a situation, make preparations, or attempt to gain leverage__, envision your action and roll. If you act...\n\n  * With speed, agility, or precision: Roll +edge.\n  * With charm, loyalty, or courage: Roll +heart.\n  * With aggressive action, forceful defense, strength, or endurance: Roll +iron.\n  * With deception, stealth, or trickery: Roll +shadow.\n  * With expertise, insight, or observation: Roll +wits.\n\nOn a __strong hit__, take both. On a __string hit with a match__, take both and mark progress. On a __weak hit__, choose one.\n\n  * Take +2 momentum\n  * Add +1 on your next move (not a progress move)\n\nOn a __miss__, you fail or your assumptions betray you. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
+					"outcomes": {
+						"strong_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.strong_hit",
+							"text": "On a __strong hit__, take +2 momentum and add +1 on your next move (not a progress move).\n\nOn a __strong hit with a match__, take +2 momentum, add +1 on your next move (not a progress move), and mark progress."
+						},
+						"weak_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.weak_hit",
+							"text": "On a __weak hit__, choose one.\n\n  * Take +2 momentum\n  * Add +1 on your next move (not a progress move)"
+						},
+						"miss": {
+							"_id": "move.outcome:lodestar/scene_challenge/secure_an_advantage.miss",
+							"text": "On a __miss__, you fail or your assumptions betray you. Mark a countdown segment and [Pay the Price](datasworn:move:classic/fate/pay_the_price). On a __miss with a match__, mark two segments and [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
+						}
+					},
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 11,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": true
+				},
+				"finish_the_scene": {
+					"_id": "move:lodestar/scene_challenge/finish_the_scene",
+					"type": "move",
+					"name": "Finish the Scene",
+					"roll_type": "progress_roll",
+					"tracks": {
+						"category": "Scene Challenge",
+						"controls": {}
+					},
+					"trigger": {
+						"conditions": [
+							{
+								"_id": "move.condition:lodestar/scene_challenge/finish_the_scene.0",
+								"method": "progress_roll",
+								"roll_options": [
+									{
+										"using": "progress_track"
+									}
+								]
+							}
+						],
+						"text": "When the scene challenge countdown track or progress track is filled, or when events lead to the scene’s conclusion..."
+					},
+					"text": "When __the scene challenge tension clock or progress track is filled, or when events lead to the scene’s conclusion__, roll the challenge dice and compare to your progress.\n\nOn a __strong hit__, you achieve your objective unconditionally.\n\nOn a __weak hit__, you succeed, but not without cost. You must [Pay the Price](datasworn:move:classic/fate/pay_the_price). Make this a minor cost relative to the scope of the scene.\n\nOn a __miss__, you fail or are undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price).",
+					"outcomes": {
+						"strong_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.strong_hit",
+							"text": "On a __strong hit__, you achieve your objective unconditionally."
+						},
+						"weak_hit": {
+							"_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.weak_hit",
+							"text": "On a __weak hit__, you succeed, but not without cost. You must [Pay the Price](datasworn:move:classic/fate/pay_the_price). Make this a minor cost relative to the scope of the scene."
+						},
+						"miss": {
+							"_id": "move.outcome:lodestar/scene_challenge/finish_the_scene.miss",
+							"text": "On a __miss__, you fail or are undermined by a dire turn of events. [Pay the Price](datasworn:move:classic/fate/pay_the_price)."
+						}
+					},
+					"oracles": {},
+					"_source": {
+						"title": "Ironsworn Lodestar",
+						"authors": [
+							{
+								"name": "Shawn Tomkin"
+							}
+						],
+						"date": "2025-05-01",
+						"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+						"page": 11,
+						"url": "https://ironswornrpg.com"
+					},
+					"allow_momentum_burn": false
+				}
+			},
+			"collections": {},
+			"_source": {
+				"title": "Ironsworn Lodestar",
+				"authors": [
+					{
+						"name": "Shawn Tomkin"
+					}
+				],
+				"date": "2025-05-01",
+				"license": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+				"page": 11,
+				"url": "https://ironswornrpg.com"
+			}
+		}
+	},
+	"npcs": {},
+	"rarities": {},
+	"delve_sites": {},
+	"site_domains": {},
+	"site_themes": {},
+	"truths": {}
 }


### PR DESCRIPTION
## Summary

- Updates `src/data/lodestar.json` from the latest `@datasworn/ironsworn-classic-lodestar` package build
- The previous version was missing several oracle collections that were added to the datasworn source but the npm package had not been rebuilt
- Now includes: character, name (including Firstborn sub-collection), location (Overland + Coastal Waters), settlement (including Quick Name and Type sub-collections), and the full story collection

## Test plan

- [ ] Verify lodestar oracles appear correctly in the expansion oracle UI
- [ ] Confirm character, location, and settlement oracle categories are populated
- [ ] Check that nested collections (Firstborn names, Overland/Coastal Waters locations, settlement Type) display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)