### PR TITLE
fix(moves): remove duplicate moves in enhancing categories

### DIFF
--- a/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.tsx
+++ b/src/components/features/charactersAndCampaigns/MovesSection/MoveCategory.tsx
@@ -7,26 +7,22 @@ import { Move } from "./Move";
 
 export interface MoveCategoryProps {
   category: Datasworn.MoveCategory;
-  categories: Record<string, Datasworn.MoveCategory>;
   moveMap: Record<string, Datasworn.Move>;
   openMove: (move: Datasworn.Move) => void;
   forceOpen?: boolean;
   visibleCategories: Record<string, CATEGORY_VISIBILITY>;
   visibleMoves: Record<string, boolean>;
   shouldExpandLocally?: boolean;
-  enhancesCollections: Record<string, string[]>;
 }
 
 export function MoveCategory(props: MoveCategoryProps) {
   const {
     category,
-    categories,
     moveMap,
     openMove,
     forceOpen,
     visibleCategories,
     visibleMoves,
-    enhancesCollections,
     shouldExpandLocally,
   } = props;
 
@@ -34,26 +30,11 @@ export function MoveCategory(props: MoveCategoryProps) {
 
   const isExpandedOrForced = isExpanded || forceOpen;
 
-  const enhancingCollectionIds = enhancesCollections[category._id];
-
   const contents = category.contents;
 
   const moveIds = useMemo(() => {
-    const moveIds = Object.values(contents ?? {}).map((move) => move._id);
-
-    (enhancingCollectionIds ?? []).forEach((enhancesId) => {
-      const enhancingCollection = categories[enhancesId];
-      if (enhancingCollection) {
-        moveIds.push(
-          ...Object.values(enhancingCollection.contents ?? {}).map(
-            (move) => move._id,
-          ),
-        );
-      }
-    });
-
-    return moveIds;
-  }, [contents, categories, enhancingCollectionIds]);
+    return Object.values(contents ?? {}).map((move) => move._id);
+  }, [contents]);
 
   if (visibleCategories[category._id] === CATEGORY_VISIBILITY.HIDDEN) {
     return null;

--- a/src/components/features/charactersAndCampaigns/MovesSection/MovesSection.tsx
+++ b/src/components/features/charactersAndCampaigns/MovesSection/MovesSection.tsx
@@ -21,7 +21,6 @@ export function MovesSection(props: MovesSectionProps) {
     visibleMoveIds,
     isSearchActive,
     isEmpty,
-    enhancesCollections,
   } = useFilterMoves();
 
   const openDialog = useStore((store) => store.appState.openDialog);
@@ -67,7 +66,6 @@ export function MovesSection(props: MovesSectionProps) {
             <MoveCategory
               key={index}
               category={moveCategories[categoryId]}
-              categories={moveCategories}
               moveMap={moveMap}
               openMove={(move) => {
                 openDialog(move._id);
@@ -76,7 +74,6 @@ export function MovesSection(props: MovesSectionProps) {
               visibleCategories={visibleMoveCategoryIds}
               visibleMoves={visibleMoveIds}
               shouldExpandLocally={shouldExpandLocally}
-              enhancesCollections={enhancesCollections}
             />
           ))
         ) : (

--- a/src/components/features/charactersAndCampaigns/MovesSection/useFilterMoves.ts
+++ b/src/components/features/charactersAndCampaigns/MovesSection/useFilterMoves.ts
@@ -23,24 +23,12 @@ export function useFilterMoves() {
     visibleMoveCategoryIds,
     visibleMoveIds,
     isEmpty,
-    enhancesCollections,
   } = useMemo(() => {
     const visibleCategories: Record<string, CATEGORY_VISIBILITY> = {};
     const visibleMoves: Record<string, boolean> = {};
     let isEmpty: boolean = true;
 
-    const enhancesCollections: Record<string, string[]> = {};
-
     Object.values(moveCategories).forEach((category) => {
-      if (category.enhances) {
-        category.enhances.forEach((enhancesId) => {
-          enhancesCollections[enhancesId] = [
-            ...(enhancesCollections[enhancesId] ?? []),
-            category._id,
-          ];
-        });
-      }
-
       if (
         !search ||
         (category.name
@@ -84,7 +72,6 @@ export function useFilterMoves() {
       visibleMoveCategoryIds: visibleCategories,
       visibleMoveIds: visibleMoves,
       isEmpty,
-      enhancesCollections,
     };
   }, [moveCategories, search]);
 
@@ -97,6 +84,5 @@ export function useFilterMoves() {
     isSearchActive: !!search,
     isEmpty,
     rootMoveCategories,
-    enhancesCollections,
   };
 }


### PR DESCRIPTION
## Summary

- Move categories that `enhances` an existing category were causing moves to appear twice
- `mergeMoveMaps` already merges the enhancing category's moves into the parent's `contents`, so `MoveCategory` rendering them again via `enhancesCollections` was redundant
- Removed the `enhancesCollections` path entirely from `useFilterMoves`, `MovesSection`, and `MoveCategory`

## Root cause

`mergeMoveMaps` in `rules.slice.ts` copies category B's `contents` into category A's `contents` when B enhances A. `MoveCategory.tsx` then pulled A's already-merged `contents` **and** separately appended B's moves via `enhancesCollections`, resulting in a double render.

## Test plan

- [ ] Enable the Lodestar expansion and open the moves panel — Exploration moves (or any category with `enhances`) should appear once, not twice
- [ ] Confirm move search still works correctly across enhancing categories
- [ ] Verify no moves are missing from enhanced categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)