### PR TITLE
feat(lodestar): promote Lodestar from beta to generally available

### DIFF
--- a/src/components/features/charactersAndCampaigns/ExpansionSelector/ExpansionSelector.tsx
+++ b/src/components/features/charactersAndCampaigns/ExpansionSelector/ExpansionSelector.tsx
@@ -12,7 +12,6 @@ import {
 import InfoIcon from "@mui/icons-material/InfoOutlined";
 import { EmptyState } from "components/shared/EmptyState";
 import { IExpansionConfig, includedExpansions } from "data/rulesets";
-import { useFeatureFlag } from "hooks/featureFlags/useFeatureFlag";
 import { buildExpansionChanges } from "./expansionCascade";
 
 export { buildExpansionChanges } from "./expansionCascade";
@@ -60,8 +59,6 @@ export function ExpansionSelector(props: ExpansionSelectorProps) {
     [GAME_SYSTEMS.STARFORGED]: "starforged",
   });
 
-  const isLodestarFlagEnabled = useFeatureFlag("lodestar");
-
   const homebrewExpansionMap = useStore((store) => store.homebrew.collections);
   const sortedExpansionIds = useStore(
     (store) => store.homebrew.sortedHomebrewCollectionIds,
@@ -69,7 +66,7 @@ export function ExpansionSelector(props: ExpansionSelectorProps) {
 
   const rulesetExpansions = Object.values(
     includedExpansions[activeRulesetId] ?? {},
-  ).filter((c) => c.id !== "lodestar" || isLodestarFlagEnabled);
+  );
 
   const officialExpansions = rulesetExpansions.filter((c) => !c.isHomebrew);
   const thirdPartyExpansions = rulesetExpansions.filter((c) => c.isHomebrew);

--- a/src/components/shared/Layout/nav/BetaTestsDialog.tsx
+++ b/src/components/shared/Layout/nav/BetaTestsDialog.tsx
@@ -15,6 +15,7 @@ import { activeFeatureFlags } from "hooks/featureFlags/activeFeatureFlags";
 import { EmptyState } from "../../EmptyState";
 import { useEffect, useState } from "react";
 import { useStore } from "stores/store";
+import { useGameSystem } from "hooks/useGameSystem";
 
 export interface BetaTestsDialogProps {
   open: boolean;
@@ -23,6 +24,8 @@ export interface BetaTestsDialogProps {
 
 export function BetaTestsDialog(props: BetaTestsDialogProps) {
   const { open, onClose } = props;
+
+  const { gameSystem } = useGameSystem();
 
   const activeBetaTests = useStore((store) => store.appState.betaTests);
   const updateBetaTests = useStore((store) => store.appState.updateBetaTests);
@@ -66,7 +69,13 @@ export function BetaTestsDialog(props: BetaTestsDialogProps) {
           <LinearProgress />
         ) : (
           <Stack spacing={2} sx={{ mt: 1 }}>
-            {activeFeatureFlags.map((flagConfig) => (
+            {activeFeatureFlags
+              .filter((config) =>
+                config.gameSystems
+                  ? config.gameSystems.includes(gameSystem)
+                  : true
+              )
+              .map((flagConfig) => (
                 <Box key={flagConfig.testId}>
                   <FormControlLabel
                     key={flagConfig.testId}

--- a/src/components/shared/Layout/nav/BetaTestsDialog.tsx
+++ b/src/components/shared/Layout/nav/BetaTestsDialog.tsx
@@ -15,7 +15,6 @@ import { activeFeatureFlags } from "hooks/featureFlags/activeFeatureFlags";
 import { EmptyState } from "../../EmptyState";
 import { useEffect, useState } from "react";
 import { useStore } from "stores/store";
-import { useGameSystem } from "hooks/useGameSystem";
 
 export interface BetaTestsDialogProps {
   open: boolean;
@@ -24,8 +23,6 @@ export interface BetaTestsDialogProps {
 
 export function BetaTestsDialog(props: BetaTestsDialogProps) {
   const { open, onClose } = props;
-
-  const { gameSystem } = useGameSystem();
 
   const activeBetaTests = useStore((store) => store.appState.betaTests);
   const updateBetaTests = useStore((store) => store.appState.updateBetaTests);
@@ -69,13 +66,7 @@ export function BetaTestsDialog(props: BetaTestsDialogProps) {
           <LinearProgress />
         ) : (
           <Stack spacing={2} sx={{ mt: 1 }}>
-            {activeFeatureFlags
-              .filter((config) =>
-                config.gameSystems
-                  ? config.gameSystems.includes(gameSystem)
-                  : true
-              )
-              .map((flagConfig) => (
+            {activeFeatureFlags.map((flagConfig) => (
                 <Box key={flagConfig.testId}>
                   <FormControlLabel
                     key={flagConfig.testId}

--- a/src/hooks/featureFlags/activeFeatureFlags.ts
+++ b/src/hooks/featureFlags/activeFeatureFlags.ts
@@ -1,5 +1,8 @@
+import { GAME_SYSTEMS } from "types/GameSystems.type";
+
 export const activeFeatureFlags: {
   testId: string;
   label: string;
   warning?: string;
+  gameSystems?: GAME_SYSTEMS[];
 }[] = [];

--- a/src/hooks/featureFlags/activeFeatureFlags.ts
+++ b/src/hooks/featureFlags/activeFeatureFlags.ts
@@ -1,14 +1,5 @@
-import { GAME_SYSTEMS } from "types/GameSystems.type";
-
 export const activeFeatureFlags: {
   testId: string;
   label: string;
   warning?: string;
-  gameSystems?: GAME_SYSTEMS[];
-}[] = [
-  {
-    testId: "lodestar",
-    label: "Enable Lodestar content (may not match book content)",
-    gameSystems: [GAME_SYSTEMS.IRONSWORN],
-  },
-];
+}[] = [];


### PR DESCRIPTION
## Summary

- Removes the `lodestar` feature flag from the beta tests list so the expansion is visible to all users without needing to opt in
- Cleans up the `gameSystems` filtering logic in `BetaTestsDialog` since it's no longer needed

## Test plan

- [ ] Open an Ironsworn character/campaign and confirm Ironsworn Lodestar appears in the expansion selector without any beta toggle
- [ ] Confirm the Beta Tests dialog shows "no active beta tests"

🤖 Generated with [Claude Code](https://claude.com/claude-code)