### PR TITLE
fix(game-log): use server timestamps for new rolls

### DIFF
--- a/src/api-calls/game-log/_getRef.ts
+++ b/src/api-calls/game-log/_getRef.ts
@@ -3,8 +3,10 @@ import {
   CollectionReference,
   DocumentReference,
   Timestamp,
+  WithFieldValue,
   collection,
   doc,
+  serverTimestamp,
 } from "firebase/firestore";
 import { Roll } from "types/DieRolls.type";
 import { GameLogDocument } from "./_game-log.type";
@@ -65,13 +67,13 @@ export function getCharacterGameLogDocument(
 export function convertFromDatabase(log: GameLogDocument): Roll {
   return {
     ...log,
-    timestamp: log.timestamp.toDate(),
+    timestamp: log.timestamp?.toDate() ?? new Date(),
   } as Roll;
 }
 
-export function convertRollToGameLogDocument(roll: Roll): GameLogDocument {
+export function convertRollToGameLogDocument(roll: Roll): WithFieldValue<GameLogDocument> {
   return {
     ...roll,
-    timestamp: Timestamp.fromDate(roll.timestamp),
+    timestamp: serverTimestamp(),
   };
 }

--- a/src/api-calls/game-log/updateLog.ts
+++ b/src/api-calls/game-log/updateLog.ts
@@ -1,8 +1,7 @@
 import { createApiFunction } from "api-calls/createApiFunction";
-import { updateDoc } from "firebase/firestore";
+import { Timestamp, updateDoc } from "firebase/firestore";
 import { Roll } from "types/DieRolls.type";
 import {
-  convertRollToGameLogDocument,
   getCampaignGameLogDocument,
   getCharacterGameLogDocument,
 } from "./_getRef";
@@ -22,7 +21,7 @@ export const updateLog = createApiFunction<
       ? getCampaignGameLogDocument(campaignId, logId)
       : getCharacterGameLogDocument(characterId as string, logId);
 
-    updateDoc(docRef, convertRollToGameLogDocument(log))
+    updateDoc(docRef, { ...log, timestamp: Timestamp.fromDate(log.timestamp) })
       .then(() => {
         resolve();
       })


### PR DESCRIPTION
## Summary

- New rolls now use Firestore `serverTimestamp()` instead of the client device clock, so a player with an incorrect system clock can no longer produce future-dated rolls that sort incorrectly for everyone in the session
- Die-reroll updates continue to use `Timestamp.fromDate()` to preserve the original roll time
- `convertFromDatabase` now handles the `null` timestamp Firestore returns while a server timestamp write is still pending

## Test plan

- [ ] Roll dice as a character in a campaign and confirm the entry appears in the correct chronological position in the game log
- [ ] Use the die-reroll feature and confirm the roll's timestamp does not change
- [ ] Confirm no TypeScript errors (`npx tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)