### PR TITLE
feat(dice): add custom dice roller

### DIFF
--- a/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
+++ b/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
@@ -43,6 +43,11 @@ export function CustomDiceRollerButton() {
 
   const handleClose = () => {
     setAnchorEl(null);
+    setDieSides("6");
+    setQuantity(1);
+    setModifier(0);
+    setCustomNotation("");
+    setIsCustomMode(false);
   };
 
   const handleSwitchToCustom = () => {

--- a/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
+++ b/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
@@ -8,7 +8,6 @@ import {
   TextField,
   ToggleButton,
   ToggleButtonGroup,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import CasinoIcon from "@mui/icons-material/Casino";
@@ -69,21 +68,22 @@ export function CustomDiceRollerButton() {
 
   return (
     <>
-      <Tooltip title="Roll Custom Dice">
-        <IconButton
-          onClick={handleOpen}
-          color="inherit"
-          aria-label="Roll Custom Dice"
-        >
-          <CasinoIcon />
-        </IconButton>
-      </Tooltip>
+      <Button
+        onClick={handleOpen}
+        color="inherit"
+        aria-label="Roll Custom Dice"
+        startIcon={<CasinoIcon />}
+        variant="outlined"
+        fullWidth
+      >
+        Roll Custom Dice
+      </Button>
       <Popover
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "center" }}
         slotProps={{ paper: { sx: { p: 2, minWidth: 300, maxWidth: 340 } } }}
       >
         <Typography variant="subtitle1" fontWeight="bold" gutterBottom>

--- a/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
+++ b/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
@@ -33,7 +33,9 @@ export function CustomDiceRollerButton() {
   }`;
 
   const notation = isCustomMode ? customNotation : builtNotation;
-  const parsedCustom = isCustomMode ? parseDiceExpression(customNotation) : null;
+  const parsedCustom = isCustomMode
+    ? parseDiceExpression(customNotation)
+    : null;
   const canRoll = isCustomMode ? !!parsedCustom : !!dieSides;
   const isInvalidCustom = isCustomMode && !!customNotation && !parsedCustom;
 
@@ -76,11 +78,10 @@ export function CustomDiceRollerButton() {
       <Button
         onClick={handleOpen}
         color="inherit"
-        aria-label="Roll Custom Dice"
         startIcon={<CasinoIcon />}
         variant="outlined"
       >
-        Roll Custom Dice
+        Roll Dice
       </Button>
       <Popover
         open={!!anchorEl}
@@ -206,7 +207,9 @@ export function CustomDiceRollerButton() {
         <Box display="flex" justifyContent="space-between" alignItems="center">
           <Button
             size="small"
-            onClick={isCustomMode ? handleSwitchToBuilder : handleSwitchToCustom}
+            onClick={
+              isCustomMode ? handleSwitchToBuilder : handleSwitchToCustom
+            }
           >
             {isCustomMode ? "Use Builder" : "Custom..."}
           </Button>

--- a/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
+++ b/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
@@ -1,0 +1,221 @@
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Divider,
+  IconButton,
+  Popover,
+  TextField,
+  ToggleButton,
+  ToggleButtonGroup,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import CasinoIcon from "@mui/icons-material/Casino";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
+import { useRoller } from "stores/appState/useRoller";
+import { parseDiceExpression } from "stores/appState/rollers/diceExpressionParser";
+
+const DIE_OPTIONS = [4, 6, 8, 10, 12, 20, 100];
+
+export function CustomDiceRollerButton() {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const [dieSides, setDieSides] = useState<string>("6");
+  const [quantity, setQuantity] = useState(1);
+  const [modifier, setModifier] = useState(0);
+  const [customNotation, setCustomNotation] = useState("");
+  const [isCustomMode, setIsCustomMode] = useState(false);
+
+  const { rollCustomDice } = useRoller();
+
+  const builtNotation = `${quantity}d${dieSides}${
+    modifier > 0 ? "+" + modifier : modifier < 0 ? modifier : ""
+  }`;
+
+  const notation = isCustomMode ? customNotation : builtNotation;
+  const parsedCustom = isCustomMode ? parseDiceExpression(customNotation) : null;
+  const canRoll = isCustomMode ? !!parsedCustom : !!dieSides;
+  const isInvalidCustom = isCustomMode && !!customNotation && !parsedCustom;
+
+  const handleOpen = (e: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(e.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleSwitchToCustom = () => {
+    setCustomNotation(builtNotation);
+    setIsCustomMode(true);
+  };
+
+  const handleSwitchToBuilder = () => {
+    const parsed = parseDiceExpression(customNotation);
+    if (parsed && DIE_OPTIONS.includes(parsed.typeOfDice)) {
+      setDieSides(String(parsed.typeOfDice));
+      setQuantity(parsed.diceCount);
+      setModifier(parsed.modifier);
+    }
+    setIsCustomMode(false);
+  };
+
+  const handleRoll = async () => {
+    if (!canRoll) return;
+    await rollCustomDice(notation);
+    handleClose();
+  };
+
+  return (
+    <>
+      <Tooltip title="Roll Custom Dice">
+        <IconButton
+          onClick={handleOpen}
+          color="inherit"
+          aria-label="Roll Custom Dice"
+        >
+          <CasinoIcon />
+        </IconButton>
+      </Tooltip>
+      <Popover
+        open={!!anchorEl}
+        anchorEl={anchorEl}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{ paper: { sx: { p: 2, minWidth: 300, maxWidth: 340 } } }}
+      >
+        <Typography variant="subtitle1" fontWeight="bold" gutterBottom>
+          Custom Dice Roll
+        </Typography>
+
+        {!isCustomMode ? (
+          <>
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              display="block"
+              mb={0.5}
+            >
+              Die Type
+            </Typography>
+            <ToggleButtonGroup
+              value={dieSides}
+              exclusive
+              onChange={(_, val) => val && setDieSides(val)}
+              size="small"
+              sx={{ flexWrap: "wrap", mb: 1.5 }}
+            >
+              {DIE_OPTIONS.map((d) => (
+                <ToggleButton key={d} value={String(d)} sx={{ minWidth: 44 }}>
+                  d{d}
+                </ToggleButton>
+              ))}
+            </ToggleButtonGroup>
+
+            <Box display="flex" gap={3} mb={1.5}>
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                >
+                  Quantity
+                </Typography>
+                <Box display="flex" alignItems="center" gap={0.5}>
+                  <IconButton
+                    size="small"
+                    onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+                    aria-label="Decrease quantity"
+                  >
+                    <RemoveIcon fontSize="small" />
+                  </IconButton>
+                  <Typography minWidth={20} textAlign="center">
+                    {quantity}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => setQuantity((q) => Math.min(20, q + 1))}
+                    aria-label="Increase quantity"
+                  >
+                    <AddIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+
+              <Box>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  display="block"
+                >
+                  Modifier
+                </Typography>
+                <Box display="flex" alignItems="center" gap={0.5}>
+                  <IconButton
+                    size="small"
+                    onClick={() => setModifier((m) => m - 1)}
+                    aria-label="Decrease modifier"
+                  >
+                    <RemoveIcon fontSize="small" />
+                  </IconButton>
+                  <Typography minWidth={24} textAlign="center">
+                    {modifier >= 0 ? `+${modifier}` : modifier}
+                  </Typography>
+                  <IconButton
+                    size="small"
+                    onClick={() => setModifier((m) => m + 1)}
+                    aria-label="Increase modifier"
+                  >
+                    <AddIcon fontSize="small" />
+                  </IconButton>
+                </Box>
+              </Box>
+            </Box>
+
+            <Typography variant="body2" color="text.secondary">
+              Notation: <strong>{builtNotation}</strong>
+            </Typography>
+          </>
+        ) : (
+          <TextField
+            fullWidth
+            label="Dice Notation"
+            placeholder="e.g. 2d20+3"
+            value={customNotation}
+            onChange={(e) => setCustomNotation(e.target.value)}
+            size="small"
+            error={isInvalidCustom}
+            helperText={
+              isInvalidCustom ? "Invalid notation (e.g. 2d20+3)" : " "
+            }
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && canRoll) handleRoll();
+            }}
+            autoFocus
+          />
+        )}
+
+        <Divider sx={{ my: 1.5 }} />
+
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Button
+            size="small"
+            onClick={isCustomMode ? handleSwitchToBuilder : handleSwitchToCustom}
+          >
+            {isCustomMode ? "Use Builder" : "Custom..."}
+          </Button>
+          <Button
+            variant="contained"
+            disabled={!canRoll}
+            onClick={handleRoll}
+            startIcon={<CasinoIcon />}
+          >
+            Roll
+          </Button>
+        </Box>
+      </Popover>
+    </>
+  );
+}

--- a/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
+++ b/src/components/features/charactersAndCampaigns/CustomDiceRollerButton.tsx
@@ -74,7 +74,6 @@ export function CustomDiceRollerButton() {
         aria-label="Roll Custom Dice"
         startIcon={<CasinoIcon />}
         variant="outlined"
-        fullWidth
       >
         Roll Custom Dice
       </Button>
@@ -82,8 +81,8 @@ export function CustomDiceRollerButton() {
         open={!!anchorEl}
         anchorEl={anchorEl}
         onClose={handleClose}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
-        transformOrigin={{ vertical: "bottom", horizontal: "center" }}
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "right" }}
         slotProps={{ paper: { sx: { p: 2, minWidth: 300, maxWidth: 340 } } }}
       >
         <Typography variant="subtitle1" fontWeight="bold" gutterBottom>

--- a/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
+++ b/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
@@ -3,6 +3,7 @@ import { useStore } from "stores/store";
 import { Virtuoso } from "react-virtuoso";
 import { Box, LinearProgress } from "@mui/material";
 import { GameLogEntry } from "./GameLogEntry";
+import { CustomDiceRollerButton } from "components/features/charactersAndCampaigns/CustomDiceRollerButton";
 
 const MAX_ITEMS = 1000000000;
 
@@ -35,17 +36,31 @@ export function GameLog() {
   }, [logLength]);
 
   return (
-    <Box sx={{ flexGrow: 1 }}>
+    <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "flex-end",
+          px: 1,
+          py: 0.5,
+          borderBottom: 1,
+          borderColor: "divider",
+        }}
+      >
+        <CustomDiceRollerButton />
+      </Box>
       {loading && <LinearProgress />}
-      <Virtuoso
-        firstItemIndex={firstItemIndex}
-        initialTopMostItemIndex={MAX_ITEMS - 1}
-        data={orderedLogKeys}
-        startReached={loadMoreLogs}
-        itemContent={(index, logId) => (
-          <GameLogEntry logId={logId} log={logs[logId]} />
-        )}
-      />
+      <Box sx={{ flexGrow: 1 }}>
+        <Virtuoso
+          firstItemIndex={firstItemIndex}
+          initialTopMostItemIndex={MAX_ITEMS - 1}
+          data={orderedLogKeys}
+          startReached={loadMoreLogs}
+          itemContent={(index, logId) => (
+            <GameLogEntry logId={logId} log={logs[logId]} />
+          )}
+        />
+      </Box>
     </Box>
   );
 }

--- a/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
+++ b/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
@@ -52,7 +52,7 @@ export function GameLog() {
       <Box
         sx={{
           display: "flex",
-          justifyContent: "stretch",
+          justifyContent: "flex-end",
           px: 1,
           py: 1,
           borderTop: 1,

--- a/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
+++ b/src/components/features/charactersAndCampaigns/GameLog/GameLog.tsx
@@ -37,18 +37,6 @@ export function GameLog() {
 
   return (
     <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
-      <Box
-        sx={{
-          display: "flex",
-          justifyContent: "flex-end",
-          px: 1,
-          py: 0.5,
-          borderBottom: 1,
-          borderColor: "divider",
-        }}
-      >
-        <CustomDiceRollerButton />
-      </Box>
       {loading && <LinearProgress />}
       <Box sx={{ flexGrow: 1 }}>
         <Virtuoso
@@ -60,6 +48,18 @@ export function GameLog() {
             <GameLogEntry logId={logId} log={logs[logId]} />
           )}
         />
+      </Box>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "stretch",
+          px: 1,
+          py: 1,
+          borderTop: 1,
+          borderColor: "divider",
+        }}
+      >
+        <CustomDiceRollerButton />
       </Box>
     </Box>
   );

--- a/src/components/features/charactersAndCampaigns/RollDisplay/RollDisplay.tsx
+++ b/src/components/features/charactersAndCampaigns/RollDisplay/RollDisplay.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, CardActionArea } from "@mui/material";
+import { Box, Card, CardActionArea, Divider, Typography } from "@mui/material";
 import { ROLL_TYPE, Roll } from "types/DieRolls.type";
 import { RollTitle } from "./RollTitle";
 import { RollValues } from "./RollValues";
@@ -150,6 +150,44 @@ export function RollDisplay(props: RollDisplayProps) {
                 markdown={roll.result}
                 extras={roll.match ? ["Match"] : undefined}
               />
+            </RollContainer>
+          </>
+        )}
+        {roll.type === ROLL_TYPE.CUSTOM_DICE && (
+          <>
+            <RollTitle title={roll.notation} isExpanded={isExpanded} />
+            <RollContainer>
+              {isExpanded && (
+                <>
+                  <Box>
+                    <Typography
+                      variant="body2"
+                      color={(theme) => theme.palette.grey[200]}
+                    >
+                      {roll.dieValues.join(", ")}
+                    </Typography>
+                    {roll.modifier !== 0 && (
+                      <Typography
+                        variant="body2"
+                        color={(theme) => theme.palette.grey[200]}
+                      >
+                        {roll.modifier > 0 ? "+" : ""}
+                        {roll.modifier}
+                      </Typography>
+                    )}
+                  </Box>
+                  <Divider
+                    orientation="vertical"
+                    sx={(theme) => ({
+                      alignSelf: "stretch",
+                      borderColor: theme.palette.grey[400],
+                      height: "auto",
+                      mx: 2,
+                    })}
+                  />
+                </>
+              )}
+              <RollResult result={String(roll.total)} />
             </RollContainer>
           </>
         )}

--- a/src/components/features/charactersAndCampaigns/RollDisplay/clipboardFormatter.ts
+++ b/src/components/features/charactersAndCampaigns/RollDisplay/clipboardFormatter.ts
@@ -1,5 +1,6 @@
 import {
   ClockProgressionRoll,
+  CustomDiceRoll,
   OracleTableRoll,
   ROLL_TYPE,
   Roll,
@@ -65,6 +66,13 @@ export function convertRollToClipboard(roll: Roll):
         plain: convertClockProgressionRollToClipboardPlain(
           clockProgressionContents
         ),
+      };
+    }
+    case ROLL_TYPE.CUSTOM_DICE: {
+      const customContents = extractCustomDiceRollContents(roll);
+      return {
+        rich: convertCustomDiceRollToClipboardRich(customContents),
+        plain: convertCustomDiceRollToClipboardPlain(customContents),
       };
     }
     default:
@@ -282,5 +290,47 @@ export function convertClockProgressionRollToClipboardPlain(
 ${contents.title}
 Roll: ${contents.roll}
 ${contents.result}
+    `;
+}
+
+interface CustomDiceRollContents {
+  notation: string;
+  dice: string;
+  total: string;
+}
+
+export function extractCustomDiceRollContents(
+  roll: CustomDiceRoll
+): CustomDiceRollContents {
+  const modifierStr =
+    roll.modifier > 0
+      ? ` + ${roll.modifier}`
+      : roll.modifier < 0
+        ? ` - ${Math.abs(roll.modifier)}`
+        : "";
+  return {
+    notation: roll.notation,
+    dice: roll.dieValues.join(", ") + modifierStr,
+    total: String(roll.total),
+  };
+}
+
+export function convertCustomDiceRollToClipboardRich(
+  contents: CustomDiceRollContents
+): string {
+  const title = formatParagraph(contents.notation);
+  const dice = formatParagraph(formatItalic("Dice: ") + contents.dice);
+  const total = formatBold(contents.total);
+
+  return formatQuote(title + dice + total);
+}
+
+export function convertCustomDiceRollToClipboardPlain(
+  contents: CustomDiceRollContents
+) {
+  return `
+${contents.notation}
+Dice: ${contents.dice}
+${contents.total}
     `;
 }

--- a/src/components/shared/StyledTabs/ContainedTabPanel.tsx
+++ b/src/components/shared/StyledTabs/ContainedTabPanel.tsx
@@ -5,10 +5,17 @@ export interface ContainedTabPanelProps extends PropsWithChildren {
   greyBackground?: boolean;
   isVisible: boolean;
   overflowAuto?: boolean;
+  excludePadding?: boolean;
 }
 
 export function ContainedTabPanel(props: ContainedTabPanelProps) {
-  const { greyBackground, isVisible, overflowAuto = true, children } = props;
+  const {
+    greyBackground,
+    isVisible,
+    overflowAuto = true,
+    excludePadding,
+    children,
+  } = props;
 
   if (!isVisible) return null;
 
@@ -23,7 +30,7 @@ export function ContainedTabPanel(props: ContainedTabPanelProps) {
         overflowY: overflowAuto ? "auto" : "scroll",
         scrollbarColor: `${theme.palette.divider} rgba(0, 0, 0, 0)`,
         scrollbarWidth: "thin",
-        pb: 2
+        pb: excludePadding ? 0 : 2,
       })}
     >
       {children}

--- a/src/pages/Campaign/CampaignPage/components/CampaignContent.tsx
+++ b/src/pages/Campaign/CampaignPage/components/CampaignContent.tsx
@@ -82,7 +82,10 @@ export function CampaignContent(props: CampaignContentProps) {
       <ContainedTabPanel isVisible={selectedTab === CampaignTabs.Tracks}>
         <TracksTab />
       </ContainedTabPanel>
-      <ContainedTabPanel isVisible={selectedTab === CampaignTabs.Notes}>
+      <ContainedTabPanel
+        excludePadding
+        isVisible={selectedTab === CampaignTabs.Notes}
+      >
         <NotesTab />
       </ContainedTabPanel>
       <ContainedTabPanel isVisible={selectedTab === CampaignTabs.World}>

--- a/src/pages/Character/CharacterSheetPage/components/TabsSection.tsx
+++ b/src/pages/Character/CharacterSheetPage/components/TabsSection.tsx
@@ -104,7 +104,7 @@ export function TabsSection() {
       <ContainedTabPanel isVisible={selectedTab === TABS.TRACKS}>
         <TracksSection />
       </ContainedTabPanel>
-      <ContainedTabPanel isVisible={selectedTab === TABS.NOTES}>
+      <ContainedTabPanel excludePadding isVisible={selectedTab === TABS.NOTES}>
         <NotesSection />
       </ContainedTabPanel>
       <ContainedTabPanel isVisible={selectedTab === TABS.WORLD}>

--- a/src/stores/appState/useRoller.ts
+++ b/src/stores/appState/useRoller.ts
@@ -2,11 +2,13 @@ import { useStore } from "stores/store";
 import { useCallback } from "react";
 import {
   ClockProgressionRoll,
+  CustomDiceRoll,
   ROLL_RESULT,
   ROLL_TYPE,
   StatRoll,
   TrackProgressRoll,
 } from "types/DieRolls.type";
+import { parseDiceExpression } from "./rollers/diceExpressionParser";
 import { getRollResultLabel } from "components/features/charactersAndCampaigns/RollDisplay";
 import { TrackTypes } from "types/Track.type";
 import { LEGACY_TrackTypes } from "types/LegacyTrack.type";
@@ -15,6 +17,8 @@ import { idMap } from "data/idMap";
 import { Datasworn, IdParser } from "@datasworn/core";
 import { Dice } from "components/shared/Dice";
 import { Theme, useTheme } from "@mui/material";
+
+const SUPPORTED_3D_DIE_SIDES = new Set([4, 6, 8, 10, 12, 20, 100]);
 
 export interface RollResult {
   value: number
@@ -402,11 +406,88 @@ export function useRoller() {
     ]
   );
 
+  const rollCustomDice = useCallback(
+    async (notation: string) => {
+      const parsed = parseDiceExpression(notation);
+      if (!parsed) return;
+
+      const { diceCount, typeOfDice, modifier } = parsed;
+      const use3D = !hide3dDice && SUPPORTED_3D_DIE_SIDES.has(typeOfDice);
+
+      let dieValues: number[];
+      if (use3D) {
+        Dice.clear().show();
+        setTimeout(() => Dice.hide("fade-out"), 100);
+        const results = await Dice.roll([
+          {
+            qty: diceCount,
+            sides: typeOfDice,
+            themeColor: theme.palette.primary.main,
+          },
+        ]);
+        dieValues = results.map((r: { value: number }) => r.value);
+      } else {
+        dieValues = Array.from({ length: diceCount }, () =>
+          Math.floor(Math.random() * typeOfDice) + 1
+        );
+      }
+
+      const total = dieValues.reduce((sum, v) => sum + v, 0) + modifier;
+
+      const customRoll: CustomDiceRoll = {
+        type: ROLL_TYPE.CUSTOM_DICE,
+        notation,
+        dieSides: typeOfDice,
+        dieValues,
+        modifier,
+        total,
+        rollLabel: notation,
+        timestamp: new Date(),
+        characterId,
+        uid,
+        gmsOnly: false,
+      };
+
+      addRollToLog({
+        campaignId,
+        characterId: characterId || undefined,
+        roll: customRoll,
+      })
+        .then((rollId) => {
+          addRollToScreen(rollId, customRoll);
+        })
+        .catch(() => {});
+
+      const modifierText =
+        modifier > 0
+          ? ` plus ${modifier}`
+          : modifier < 0
+            ? ` minus ${Math.abs(modifier)}`
+            : "";
+      announce(
+        `Rolled ${notation}. Got ${dieValues.join(", ")}${modifierText} for a total of ${total}`
+      );
+
+      return total;
+    },
+    [
+      addRollToLog,
+      addRollToScreen,
+      announce,
+      campaignId,
+      characterId,
+      uid,
+      hide3dDice,
+      theme,
+    ]
+  );
+
   return {
     rollStat,
     rollClockProgression,
     rollTrackProgress,
     rollOracleTable,
+    rollCustomDice,
   };
 }
 

--- a/src/types/DieRolls.type.ts
+++ b/src/types/DieRolls.type.ts
@@ -12,6 +12,7 @@ export enum ROLL_TYPE {
   ORACLE_TABLE,
   TRACK_PROGRESS,
   CLOCK_PROGRESSION,
+  CUSTOM_DICE,
 }
 
 export interface BaseRoll {
@@ -66,8 +67,18 @@ export interface ClockProgressionRoll extends BaseRoll {
   match?: boolean;
 }
 
+export interface CustomDiceRoll extends BaseRoll {
+  type: ROLL_TYPE.CUSTOM_DICE;
+  notation: string;
+  dieSides: number;
+  dieValues: number[];
+  modifier: number;
+  total: number;
+}
+
 export type Roll =
   | StatRoll
   | OracleTableRoll
   | TrackProgressRoll
-  | ClockProgressionRoll;
+  | ClockProgressionRoll
+  | CustomDiceRoll;


### PR DESCRIPTION
## Summary

- Adds a new `ROLL_TYPE.CUSTOM_DICE` roll type with a `CustomDiceRoll` interface storing notation, individual die values, modifier, and total
- Adds `rollCustomDice(notation)` to `useRoller` — uses 3D dice rendering for standard die types (d4, d6, d8, d10, d12, d20, d100) when enabled, falls back to RNG for non-standard sizes
- Adds a `CustomDiceRollerButton` popover in the game log toolbar (accessible from both character sheet and campaign Notes tab) with:
  - Toggle buttons for standard die types
  - Quantity (1–20) and modifier steppers with live notation preview
  - "Custom..." mode for typing free-form notation (e.g. `3d8-2`) with validation and Enter-to-roll
- Updates `RollDisplay` to render custom dice rolls (notation as title, individual values when expanded, total always visible)
- Updates clipboard formatter to support copying custom dice rolls

## Test plan

- [ ] Open the roll log from a character sheet or campaign Notes tab
- [ ] Click the dice icon button in the toolbar — popover should open
- [ ] Select a die type (e.g. d20), set quantity to 2, modifier to +3 — notation preview shows `2d20+3`
- [ ] Click Roll — 3D dice should animate (if enabled), roll appears in log and snackbar showing individual values and total
- [ ] Try a non-standard die type via "Custom..." (e.g. `1d7`) — should roll with RNG, no 3D animation
- [ ] Verify "Use Builder" pre-fills controls when the custom notation matches a standard die type
- [ ] Copy a custom roll to clipboard and verify the formatted output
- [ ] Confirm existing stat, oracle, track progress, and clock rolls are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)