### PR TITLE
feat: track streamer overlay page views in PostHog

### DIFF
--- a/src/lib/analytics.lib.ts
+++ b/src/lib/analytics.lib.ts
@@ -42,3 +42,8 @@ export function reportPageError(
     pathname,
   });
 }
+
+export function sendStreamerOverlayViewedEvent(characterId: string) {
+  if (!analyticsEnabled) return;
+  posthog.capture("streamer-overlay-viewed", { characterId });
+}

--- a/src/pages/Character/CharacterCardPage/CharacterCardPage.tsx
+++ b/src/pages/Character/CharacterCardPage/CharacterCardPage.tsx
@@ -11,6 +11,7 @@ import { RollCard } from "./components/RollCard";
 import { useSearchParams } from "react-router-dom";
 import { useInitiativeStatusText } from "components/features/characters/InitiativeStatusChip/useInitiativeStatusText";
 import { InitiativeStatus } from "api-calls/character/_character.type";
+import { sendStreamerOverlayViewedEvent } from "lib/analytics.lib";
 
 export function CharacterCardPage() {
   const [params] = useSearchParams();
@@ -45,6 +46,12 @@ export function CharacterCardPage() {
       unsubscribe && unsubscribe();
     };
   }, [characterId, campaignId]);
+
+  useEffect(() => {
+    if (characterId) {
+      sendStreamerOverlayViewedEvent(characterId);
+    }
+  }, [characterId]);
 
   useEffect(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION
## Why this is needed

The OBS streamer-overlay page (`CHARACTER_ROUTES.CARD`) is mounted **outside** the `<Layout />` route tree in `src/Router.tsx`. The app disables PostHog's automatic pageview capture (`capture_pageview: false`) and instead fires a manual `$pageview` from `src/components/shared/Layout/LayoutPathListener.tsx` — but that listener is never reached for the card route, so the page currently sends **zero** analytics events. We need usage data to make an informed port-vs-cut decision before the app is sunset.

## What changed

- **`src/lib/analytics.lib.ts`** — added `sendStreamerOverlayViewedEvent(characterId: string)`, following the exact existing pattern (guard on `analyticsEnabled`, then `posthog.capture`). Fires the event `"streamer-overlay-viewed"` with the character ID as a property.

- **`src/pages/Character/CharacterCardPage/CharacterCardPage.tsx`** — added a `useEffect` keyed on `characterId` (sourced from the existing `useListenToCharacter()` hook) that calls the new function once per mount/character. No other changes.

No other files touched. This is a deliberately minimal one-event addition.

## Verification

- `npx tsc --noEmit` — **0 errors**
- `npm run lint` — **0 new issues** (3 pre-existing warnings/errors on `prod` are unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)