### PR TITLE
[codex] Reorganize tracks tabs

### DIFF
--- a/src/api-calls/game-log/_getRef.ts
+++ b/src/api-calls/game-log/_getRef.ts
@@ -2,7 +2,6 @@ import { firestore } from "config/firebase.config";
 import {
   CollectionReference,
   DocumentReference,
-  Timestamp,
   WithFieldValue,
   collection,
   doc,

--- a/src/components/features/ProgressTrack/EditOrCreateTrackDialog.tsx
+++ b/src/components/features/ProgressTrack/EditOrCreateTrackDialog.tsx
@@ -25,7 +25,6 @@ import {
 } from "types/Track.type";
 import {
   TrackCreateScopeField,
-  TrackCreateScopeOption,
 } from "./TrackCreateScopeField";
 
 export interface EditOrCreateTrackDialogProps {
@@ -39,9 +38,9 @@ export interface EditOrCreateTrackDialogProps {
     track: ProgressTrack | SceneChallenge
   ) => Promise<boolean | void>;
   createScopeLabel?: string;
-  createScopeOptions?: TrackCreateScopeOption[];
-  createScopeValue?: string;
-  onCreateScopeChange?: (value: string) => void;
+  createScopeChecked?: boolean;
+  createScopeHelperText?: string;
+  onCreateScopeChange?: (checked: boolean) => void;
 }
 
 export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
@@ -54,8 +53,8 @@ export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
     onDelete,
     handleTrack,
     createScopeLabel,
-    createScopeOptions,
-    createScopeValue,
+    createScopeChecked,
+    createScopeHelperText,
     onCreateScopeChange,
   } = props;
 
@@ -194,13 +193,13 @@ export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
             />
             {!initialTrack &&
               createScopeLabel &&
-              createScopeOptions &&
-              createScopeValue &&
+              createScopeHelperText &&
+              createScopeChecked !== undefined &&
               onCreateScopeChange && (
                 <TrackCreateScopeField
                   label={createScopeLabel}
-                  options={createScopeOptions}
-                  value={createScopeValue}
+                  checked={createScopeChecked}
+                  helperText={createScopeHelperText}
                   onChange={onCreateScopeChange}
                 />
               )}

--- a/src/components/features/ProgressTrack/EditOrCreateTrackDialog.tsx
+++ b/src/components/features/ProgressTrack/EditOrCreateTrackDialog.tsx
@@ -23,6 +23,10 @@ import {
   TrackTypes,
   SceneChallenge,
 } from "types/Track.type";
+import {
+  TrackCreateScopeField,
+  TrackCreateScopeOption,
+} from "./TrackCreateScopeField";
 
 export interface EditOrCreateTrackDialogProps {
   open: boolean;
@@ -34,6 +38,10 @@ export interface EditOrCreateTrackDialogProps {
   handleTrack: (
     track: ProgressTrack | SceneChallenge
   ) => Promise<boolean | void>;
+  createScopeLabel?: string;
+  createScopeOptions?: TrackCreateScopeOption[];
+  createScopeValue?: string;
+  onCreateScopeChange?: (value: string) => void;
 }
 
 export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
@@ -45,6 +53,10 @@ export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
     trackTypeName,
     onDelete,
     handleTrack,
+    createScopeLabel,
+    createScopeOptions,
+    createScopeValue,
+    onCreateScopeChange,
   } = props;
 
   const confirm = useConfirm();
@@ -180,6 +192,18 @@ export function EditOrCreateTrackDialog(props: EditOrCreateTrackDialogProps) {
               multiline
               minRows={3}
             />
+            {!initialTrack &&
+              createScopeLabel &&
+              createScopeOptions &&
+              createScopeValue &&
+              onCreateScopeChange && (
+                <TrackCreateScopeField
+                  label={createScopeLabel}
+                  options={createScopeOptions}
+                  value={createScopeValue}
+                  onChange={onCreateScopeChange}
+                />
+              )}
             <TextField
               label={"Difficulty"}
               value={difficulty ?? "-1"}

--- a/src/components/features/ProgressTrack/ProgressTrack.tsx
+++ b/src/components/features/ProgressTrack/ProgressTrack.tsx
@@ -21,32 +21,10 @@ import CompleteIcon from "@mui/icons-material/Check";
 import DieIcon from "@mui/icons-material/Casino";
 import { useConfirm } from "material-ui-confirm";
 import { useRoller } from "stores/appState/useRoller";
-import { GAME_SYSTEMS, GameSystemChooser } from "types/GameSystems.type";
 import { useGameSystemValue } from "hooks/useGameSystemValue";
 import { useStore } from "stores/store";
 import { DebouncedClockCircle } from "../charactersAndCampaigns/Clocks/DebouncedClockCircle";
-
-export const trackMoveIdSystemValues: GameSystemChooser<{
-  [key in ProgressTracks | TrackTypes.SceneChallenge]: string;
-}> = {
-  [GAME_SYSTEMS.IRONSWORN]: {
-    [TrackTypes.Vow]: "move:classic/quest/fulfill_your_vow",
-    [TrackTypes.Journey]: "move:classic/adventure/reach_your_destination",
-    [TrackTypes.Fray]: "move:classic/combat/end_the_fight",
-    [TrackTypes.DelveSite]: "move:delve/delve/locate_your_objective",
-    [TrackTypes.SceneChallenge]: "",
-    [TrackTypes.BondProgress]: "",
-  },
-  [GAME_SYSTEMS.STARFORGED]: {
-    [TrackTypes.Vow]: "move:starforged/quest/fulfill_your_vow",
-    [TrackTypes.Journey]: "move:starforged/exploration/finish_an_expedition",
-    [TrackTypes.Fray]: "move:starforged/combat/take_decisive_action",
-    [TrackTypes.DelveSite]: "",
-    [TrackTypes.BondProgress]: "move:starforged/connection/forge_a_bond",
-    [TrackTypes.SceneChallenge]:
-      "move:starforged/scene_challenge/finish_the_scene",
-  },
-};
+import { trackMoveIdSystemValues } from "./trackMoveIdSystemValues";
 
 export interface BaseProgressTrackProps {
   trackType?: ProgressTracks | TrackTypes.SceneChallenge;
@@ -212,7 +190,7 @@ export function ProgressTrack(props: ProgressTracksProps) {
 
   const handleRollClick = () => {
     if (trackType) {
-      openDialog(trackMoveIds[trackType]);
+      openDialog(resolvedTrackMoveIds[trackType]);
       rollTrackProgress(
         label || "",
         alwaysRollMax ? 10 : Math.min(Math.floor(value / 4), 10),

--- a/src/components/features/ProgressTrack/TrackCreateScopeField.tsx
+++ b/src/components/features/ProgressTrack/TrackCreateScopeField.tsx
@@ -1,0 +1,47 @@
+import {
+  FormControl,
+  FormControlLabel,
+  FormLabel,
+  Radio,
+  RadioGroup,
+} from "@mui/material";
+
+export interface TrackCreateScopeOption {
+  value: string;
+  label: string;
+}
+
+export interface TrackCreateScopeFieldProps {
+  label: string;
+  options: TrackCreateScopeOption[];
+  value: string;
+  onChange: (value: string) => void;
+}
+
+export function TrackCreateScopeField(props: TrackCreateScopeFieldProps) {
+  const { label, options, value, onChange } = props;
+
+  if (options.length < 2) {
+    return null;
+  }
+
+  return (
+    <FormControl>
+      <FormLabel>{label}</FormLabel>
+      <RadioGroup
+        row
+        value={value}
+        onChange={(evt) => onChange(evt.target.value)}
+      >
+        {options.map((option) => (
+          <FormControlLabel
+            key={option.value}
+            value={option.value}
+            control={<Radio />}
+            label={option.label}
+          />
+        ))}
+      </RadioGroup>
+    </FormControl>
+  );
+}

--- a/src/components/features/ProgressTrack/TrackCreateScopeField.tsx
+++ b/src/components/features/ProgressTrack/TrackCreateScopeField.tsx
@@ -1,47 +1,32 @@
 import {
+  Checkbox,
   FormControl,
   FormControlLabel,
-  FormLabel,
-  Radio,
-  RadioGroup,
+  FormHelperText,
 } from "@mui/material";
-
-export interface TrackCreateScopeOption {
-  value: string;
-  label: string;
-}
 
 export interface TrackCreateScopeFieldProps {
   label: string;
-  options: TrackCreateScopeOption[];
-  value: string;
-  onChange: (value: string) => void;
+  checked: boolean;
+  helperText: string;
+  onChange: (checked: boolean) => void;
 }
 
 export function TrackCreateScopeField(props: TrackCreateScopeFieldProps) {
-  const { label, options, value, onChange } = props;
-
-  if (options.length < 2) {
-    return null;
-  }
+  const { label, checked, helperText, onChange } = props;
 
   return (
     <FormControl>
-      <FormLabel>{label}</FormLabel>
-      <RadioGroup
-        row
-        value={value}
-        onChange={(evt) => onChange(evt.target.value)}
-      >
-        {options.map((option) => (
-          <FormControlLabel
-            key={option.value}
-            value={option.value}
-            control={<Radio />}
-            label={option.label}
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={checked}
+            onChange={(_, nextChecked) => onChange(nextChecked)}
           />
-        ))}
-      </RadioGroup>
+        }
+        label={label}
+      />
+      <FormHelperText sx={{ mt: 0 }}>{helperText}</FormHelperText>
     </FormControl>
   );
 }

--- a/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
+++ b/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
@@ -345,6 +345,7 @@ export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
               <UnifiedTrackListItem
                 item={item}
                 isStarforged={isStarforged}
+                showSourceChip={mode === "campaign" || isInCampaign}
               />
             </Box>
           ))
@@ -396,8 +397,9 @@ export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
 function UnifiedTrackListItem(props: {
   item: UnifiedTrackItem;
   isStarforged: boolean;
+  showSourceChip: boolean;
 }) {
-  const { item, isStarforged } = props;
+  const { item, isStarforged, showSourceChip } = props;
   const { track } = item;
 
   const [editing, setEditing] = useState(false);
@@ -409,7 +411,7 @@ function UnifiedTrackListItem(props: {
 
   const metadata = (
     <Stack direction={"row"} spacing={1} mb={1} flexWrap={"wrap"} useFlexGap>
-      <Chip size={"small"} label={item.sourceLabel} />
+      {showSourceChip && <Chip size={"small"} label={item.sourceLabel} />}
       <Chip size={"small"} label={getTrackTypeLabel(track.type, isStarforged)} />
     </Stack>
   );

--- a/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
+++ b/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
@@ -1,0 +1,633 @@
+import {
+  Box,
+  Button,
+  Checkbox,
+  Chip,
+  Divider,
+  FormControlLabel,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Stack,
+} from "@mui/material";
+import { EmptyState } from "components/shared/EmptyState";
+import { SectionHeading } from "components/shared/SectionHeading";
+import { Clock } from "components/features/charactersAndCampaigns/Clocks/Clock";
+import { ClockDialog } from "components/features/charactersAndCampaigns/Clocks/ClockDialog";
+import { useCampaignType } from "hooks/useCampaignType";
+import { useGameSystem } from "hooks/useGameSystem";
+import { useIsMobile } from "hooks/useIsMobile";
+import { useMemo, useRef, useState } from "react";
+import { useStore } from "stores/store";
+import { GAME_SYSTEMS } from "types/GameSystems.type";
+import {
+  ProgressTrack as IProgressTrack,
+  SceneChallenge,
+  Track,
+  TrackSectionProgressTracks,
+  TrackSectionTracks,
+  TrackStatus,
+  TrackTypes,
+} from "types/Track.type";
+import { EditOrCreateTrackDialog } from "./EditOrCreateTrackDialog";
+import { ProgressTrack } from "./ProgressTrack";
+import { TrackCreateScopeOption } from "./TrackCreateScopeField";
+import {
+  getAvailableTrackTypes,
+  getTrackTypeLabel,
+} from "./trackTypeLabels";
+
+type CreateSource = "campaign" | "character";
+type UnifiedTrackSectionMode = "campaign" | "character";
+
+type TrackMapByType = Record<TrackSectionTracks, Record<string, Track>>;
+
+interface UnifiedTrackItem {
+  key: string;
+  id: string;
+  track: Track;
+  sourceLabel: string;
+  allowEdit: boolean;
+  allowDelete: boolean;
+  updateTrack?: (trackId: string, track: Partial<Track>) => Promise<void>;
+  deleteTrack?: (trackId: string) => Promise<void>;
+}
+
+export interface UnifiedTracksSectionProps {
+  mode: UnifiedTrackSectionMode;
+  headingBreakContainer?: boolean;
+}
+
+const allTrackTypes: TrackSectionTracks[] = [
+  TrackTypes.Fray,
+  TrackTypes.Journey,
+  TrackTypes.Vow,
+  TrackTypes.DelveSite,
+  TrackTypes.SceneChallenge,
+  TrackTypes.Clock,
+];
+
+const createScopeOptions: TrackCreateScopeOption[] = [
+  { value: "campaign", label: "Shared" },
+  { value: "character", label: "Character" },
+];
+
+export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
+  const { mode, headingBreakContainer } = props;
+
+  const isStarforged = useGameSystem().gameSystem === GAME_SYSTEMS.STARFORGED;
+  const isIronsworn = useGameSystem().gameSystem === GAME_SYSTEMS.IRONSWORN;
+  const isDelveEnabled = useStore((store) =>
+    store.rules.expansionIds.includes("delve")
+  );
+  const isLodestarEnabled = useStore((store) =>
+    store.rules.expansionIds.includes("lodestar")
+  );
+  const isInCampaign = useStore(
+    (store) => !!store.campaigns.currentCampaign.currentCampaignId
+  );
+  const { hasMultipleCharacters } = useCampaignType();
+
+  const setLoadCompletedCharacterTracks = useStore(
+    (store) => store.characters.currentCharacter.tracks.setLoadCompletedTracks
+  );
+  const setLoadCompletedCampaignTracks = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.setLoadCompletedTracks
+  );
+
+  const characterTrackMap = useStore(
+    (store) => store.characters.currentCharacter.tracks.trackMap
+  );
+  const campaignTrackMap = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.trackMap
+  );
+  const campaignCharacterTracks = useStore(
+    (store) => store.campaigns.currentCampaign.characters.characterTracks
+  );
+  const campaignCharacters = useStore(
+    (store) => store.campaigns.currentCampaign.characters.characterMap
+  );
+
+  const addCharacterTrack = useStore(
+    (store) => store.characters.currentCharacter.tracks.addTrack
+  );
+  const addCampaignTrack = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.addTrack
+  );
+  const updateCharacterTrack = useStore(
+    (store) => store.characters.currentCharacter.tracks.updateTrack
+  );
+  const updateCampaignTrack = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.updateTrack
+  );
+  const updateCampaignCharacterTrack = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.updateCharacterTrack
+  );
+  const deleteCharacterTrack = useStore(
+    (store) => store.characters.currentCharacter.tracks.deleteTrack
+  );
+  const deleteCampaignTrack = useStore(
+    (store) => store.campaigns.currentCampaign.tracks.deleteTrack
+  );
+
+  const [showCompletedTracks, setShowCompletedTracks] = useState(false);
+  const [createTrackType, setCreateTrackType] = useState<TrackSectionTracks>();
+  const [createSource, setCreateSource] = useState<CreateSource>("character");
+  const [addMenuOpen, setAddMenuOpen] = useState(false);
+  const addMenuRef = useRef<HTMLButtonElement | null>(null);
+
+  const availableTrackTypes = getAvailableTrackTypes({
+    isDelveEnabled,
+    isIronsworn,
+    isLodestarEnabled,
+    isStarforged,
+  });
+
+  const canChooseCreateSource = mode === "character" && isInCampaign;
+  const defaultCreateSource: CreateSource =
+    mode === "campaign" || (isInCampaign && hasMultipleCharacters)
+      ? "campaign"
+      : "character";
+
+  const items = useMemo(() => {
+    const nextItems: UnifiedTrackItem[] = [];
+
+    if (mode === "character") {
+      addTrackMapItems({
+        items: nextItems,
+        keyPrefix: "character",
+        sourceLabel: "Character",
+        trackMap: characterTrackMap[TrackStatus.Active] as TrackMapByType,
+        updateTrack: updateCharacterTrack,
+        deleteTrack: deleteCharacterTrack,
+      });
+      if (showCompletedTracks) {
+        addTrackMapItems({
+          items: nextItems,
+          keyPrefix: "character-completed",
+          sourceLabel: "Character",
+          trackMap: characterTrackMap[TrackStatus.Completed] as TrackMapByType,
+          updateTrack: updateCharacterTrack,
+          deleteTrack: deleteCharacterTrack,
+        });
+      }
+      if (isInCampaign) {
+        addTrackMapItems({
+          items: nextItems,
+          keyPrefix: "campaign",
+          sourceLabel: "Shared",
+          trackMap: campaignTrackMap[TrackStatus.Active] as TrackMapByType,
+          updateTrack: updateCampaignTrack,
+          deleteTrack: deleteCampaignTrack,
+        });
+        if (showCompletedTracks) {
+          addTrackMapItems({
+            items: nextItems,
+            keyPrefix: "campaign-completed",
+            sourceLabel: "Shared",
+            trackMap: campaignTrackMap[TrackStatus.Completed] as TrackMapByType,
+            updateTrack: updateCampaignTrack,
+            deleteTrack: deleteCampaignTrack,
+          });
+        }
+      }
+    } else {
+      addTrackMapItems({
+        items: nextItems,
+        keyPrefix: "campaign",
+        sourceLabel: "Shared",
+        trackMap: campaignTrackMap[TrackStatus.Active] as TrackMapByType,
+        updateTrack: updateCampaignTrack,
+        deleteTrack: deleteCampaignTrack,
+      });
+      if (showCompletedTracks) {
+        addTrackMapItems({
+          items: nextItems,
+          keyPrefix: "campaign-completed",
+          sourceLabel: "Shared",
+          trackMap: campaignTrackMap[TrackStatus.Completed] as TrackMapByType,
+          updateTrack: updateCampaignTrack,
+          deleteTrack: deleteCampaignTrack,
+        });
+      }
+      Object.entries(campaignCharacterTracks).forEach(
+        ([characterId, trackMap]) => {
+          const characterName =
+            campaignCharacters[characterId]?.name ?? "Character";
+          allTrackTypes.forEach((trackType) => {
+            Object.entries(trackMap[trackType] ?? {}).forEach(
+              ([trackId, track]) => {
+                if (
+                  !showCompletedTracks &&
+                  track.status === TrackStatus.Completed
+                ) {
+                  return;
+                }
+                nextItems.push({
+                  key: `campaign-character-${characterId}-${trackId}`,
+                  id: trackId,
+                  track,
+                  sourceLabel: characterName,
+                  allowEdit: false,
+                  allowDelete: false,
+                  updateTrack: (id, trackUpdate) =>
+                    updateCampaignCharacterTrack(characterId, id, trackUpdate),
+                });
+              }
+            );
+          });
+        }
+      );
+    }
+
+    return nextItems.sort(sortTrackItems);
+  }, [
+    campaignCharacterTracks,
+    campaignCharacters,
+    campaignTrackMap,
+    characterTrackMap,
+    deleteCampaignTrack,
+    deleteCharacterTrack,
+    isInCampaign,
+    mode,
+    showCompletedTracks,
+    updateCampaignCharacterTrack,
+    updateCampaignTrack,
+    updateCharacterTrack,
+  ]);
+
+  const toggleShowCompletedTracks = (value: boolean) => {
+    if (value) {
+      if (mode === "character") {
+        setLoadCompletedCharacterTracks();
+      }
+      if (mode === "campaign" || isInCampaign) {
+        setLoadCompletedCampaignTracks();
+      }
+    }
+    setShowCompletedTracks(value);
+  };
+
+  const openCreateDialog = (trackType: TrackSectionTracks) => {
+    setCreateSource(defaultCreateSource);
+    setCreateTrackType(trackType);
+    setAddMenuOpen(false);
+  };
+
+  const closeCreateDialog = () => {
+    setCreateTrackType(undefined);
+  };
+
+  const handleAddTrack = (track: Track) => {
+    return createSource === "campaign"
+      ? addCampaignTrack(track)
+      : addCharacterTrack(track);
+  };
+
+  const isMobile = useIsMobile();
+
+  return (
+    <>
+      <SectionHeading
+        breakContainer={headingBreakContainer}
+        label={"Tracks"}
+        action={
+          <>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={showCompletedTracks}
+                  onChange={(_, checked) => toggleShowCompletedTracks(checked)}
+                />
+              }
+              label={"Show Completed"}
+            />
+            <Button
+              color={"inherit"}
+              ref={addMenuRef}
+              onClick={() => setAddMenuOpen(true)}
+            >
+              Add Track
+            </Button>
+          </>
+        }
+      />
+      <Menu
+        open={addMenuOpen}
+        anchorEl={addMenuRef.current}
+        onClose={() => setAddMenuOpen(false)}
+      >
+        {availableTrackTypes.map((trackType) => (
+          <MenuItem key={trackType} onClick={() => openCreateDialog(trackType)}>
+            <ListItemText primary={getTrackTypeLabel(trackType, isStarforged)} />
+          </MenuItem>
+        ))}
+      </Menu>
+      <Stack
+        mt={2}
+        spacing={4}
+        mb={4}
+        sx={(theme) => ({
+          px: headingBreakContainer ? 0 : 2,
+          [theme.breakpoints.up("md")]: {
+            px: headingBreakContainer ? 0 : 3,
+          },
+          alignItems: isMobile ? "center" : undefined,
+        })}
+      >
+        {items.length > 0 ? (
+          items.map((item, index) => (
+            <Box key={item.key} width={isMobile ? "fit-content" : "100%"}>
+              {showCompletedTracks &&
+                index > 0 &&
+                item.track.status === TrackStatus.Completed &&
+                items[index - 1].track.status !== TrackStatus.Completed && (
+                  <Divider sx={{ mb: 4 }}>Completed Tracks</Divider>
+                )}
+              <UnifiedTrackListItem
+                item={item}
+                isStarforged={isStarforged}
+              />
+            </Box>
+          ))
+        ) : (
+          <EmptyState message={"No tracks found"} />
+        )}
+      </Stack>
+      {createTrackType &&
+        (createTrackType === TrackTypes.Clock ? (
+          <ClockDialog
+            open={!!createTrackType}
+            handleClose={closeCreateDialog}
+            shared={createSource === "campaign"}
+            createScopeLabel={canChooseCreateSource ? "Track owner" : undefined}
+            createScopeOptions={
+              canChooseCreateSource ? createScopeOptions : undefined
+            }
+            createScopeValue={createSource}
+            onCreateScopeChange={(value) =>
+              setCreateSource(value as CreateSource)
+            }
+            onClock={handleAddTrack}
+          />
+        ) : (
+          <EditOrCreateTrackDialog
+            open={!!createTrackType}
+            handleClose={closeCreateDialog}
+            trackType={createTrackType}
+            trackTypeName={getTrackTypeLabel(createTrackType, isStarforged)}
+            createScopeLabel={canChooseCreateSource ? "Track owner" : undefined}
+            createScopeOptions={
+              canChooseCreateSource ? createScopeOptions : undefined
+            }
+            createScopeValue={createSource}
+            onCreateScopeChange={(value) =>
+              setCreateSource(value as CreateSource)
+            }
+            handleTrack={handleAddTrack}
+          />
+        ))}
+    </>
+  );
+}
+
+function UnifiedTrackListItem(props: {
+  item: UnifiedTrackItem;
+  isStarforged: boolean;
+}) {
+  const { item, isStarforged } = props;
+  const { track } = item;
+
+  const [editing, setEditing] = useState(false);
+  const canUpdate = !!item.updateTrack;
+  const isCompleted = track.status === TrackStatus.Completed;
+  const canChangeActiveTrack = canUpdate && !isCompleted;
+  const canEdit = canChangeActiveTrack && item.allowEdit;
+  const canDelete = item.allowDelete && !!item.deleteTrack;
+
+  const metadata = (
+    <Stack direction={"row"} spacing={1} mb={1} flexWrap={"wrap"} useFlexGap>
+      <Chip size={"small"} label={item.sourceLabel} />
+      <Chip size={"small"} label={getTrackTypeLabel(track.type, isStarforged)} />
+    </Stack>
+  );
+
+  if (track.type === TrackTypes.Clock) {
+    return (
+      <>
+        {metadata}
+        <Clock
+          clock={track}
+          onEdit={canEdit ? () => setEditing(true) : undefined}
+          onSelectedOracleChange={
+            canChangeActiveTrack
+              ? (oracleKey) =>
+                  item.updateTrack?.(item.id, { oracleKey }).catch(() => {})
+              : undefined
+          }
+          onComplete={
+            canChangeActiveTrack
+              ? () =>
+                  item
+                    .updateTrack?.(item.id, { status: TrackStatus.Completed })
+                    .catch(() => {})
+              : undefined
+          }
+          onValueChange={
+            canChangeActiveTrack
+              ? (value) => item.updateTrack?.(item.id, { value }).catch(() => {})
+              : undefined
+          }
+          handleDelete={
+            canDelete
+              ? () => item.deleteTrack?.(item.id).catch(() => {})
+              : undefined
+          }
+        />
+        {editing && (
+          <ClockDialog
+            initialClock={track}
+            open={editing}
+            handleClose={() => setEditing(false)}
+            onClock={(updatedTrack) =>
+              item.updateTrack?.(item.id, updatedTrack) ?? Promise.resolve()
+            }
+          />
+        )}
+      </>
+    );
+  }
+
+  if (track.type === TrackTypes.SceneChallenge) {
+    return (
+      <>
+        {metadata}
+        <ProgressTrack
+          status={track.status}
+          trackType={TrackTypes.SceneChallenge}
+          label={track.label}
+          description={track.description}
+          difficulty={track.difficulty}
+          value={track.value}
+          max={40}
+          onValueChange={
+            canChangeActiveTrack
+              ? (value) => item.updateTrack?.(item.id, { value }).catch(() => {})
+              : undefined
+          }
+          onComplete={
+            canChangeActiveTrack
+              ? () =>
+                  item
+                    .updateTrack?.(item.id, { status: TrackStatus.Completed })
+                    .catch(() => {})
+              : undefined
+          }
+          onReopen={
+            canUpdate && isCompleted
+              ? () =>
+                  item
+                    .updateTrack?.(item.id, { status: TrackStatus.Active })
+                    .catch(() => {})
+              : undefined
+          }
+          onEdit={canEdit ? () => setEditing(true) : undefined}
+          onDelete={
+            canDelete
+              ? () => item.deleteTrack?.(item.id).catch(() => {})
+              : undefined
+          }
+          hideRollButton={!canChangeActiveTrack}
+          sceneChallenge={{
+            filledSegments: track.segmentsFilled,
+            onChange: canChangeActiveTrack
+              ? (segmentsFilled: number) =>
+                  item.updateTrack?.(item.id, { segmentsFilled }).catch(() => {})
+              : undefined,
+          }}
+        />
+        {editing && (
+          <EditOrCreateTrackDialog
+            open={editing}
+            handleClose={() => setEditing(false)}
+            trackType={TrackTypes.SceneChallenge}
+            trackTypeName={getTrackTypeLabel(track.type, isStarforged)}
+            initialTrack={track}
+            onDelete={
+              canDelete
+                ? () => item.deleteTrack?.(item.id) ?? Promise.resolve()
+                : undefined
+            }
+            handleTrack={(updatedTrack) =>
+              item.updateTrack?.(item.id, updatedTrack) ?? Promise.resolve()
+            }
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {metadata}
+      <ProgressTrack
+        status={track.status}
+        trackType={track.type as TrackSectionProgressTracks}
+        label={track.label}
+        description={track.description}
+        difficulty={track.difficulty}
+        value={track.value}
+        max={40}
+        onValueChange={
+          canChangeActiveTrack
+            ? (value) => item.updateTrack?.(item.id, { value }).catch(() => {})
+            : undefined
+        }
+        onComplete={
+          canChangeActiveTrack
+            ? () =>
+                item
+                  .updateTrack?.(item.id, { status: TrackStatus.Completed })
+                  .catch(() => {})
+            : undefined
+        }
+        onReopen={
+          canUpdate && isCompleted
+            ? () =>
+                item
+                  .updateTrack?.(item.id, { status: TrackStatus.Active })
+                  .catch(() => {})
+            : undefined
+        }
+        onEdit={canEdit ? () => setEditing(true) : undefined}
+        onDelete={
+          canDelete
+            ? () => item.deleteTrack?.(item.id).catch(() => {})
+            : undefined
+        }
+        hideRollButton={!canChangeActiveTrack}
+      />
+      {editing && (
+        <EditOrCreateTrackDialog
+          open={editing}
+          handleClose={() => setEditing(false)}
+          trackType={track.type as TrackSectionProgressTracks}
+          trackTypeName={getTrackTypeLabel(track.type, isStarforged)}
+          initialTrack={track as IProgressTrack | SceneChallenge}
+          onDelete={
+            canDelete
+              ? () => item.deleteTrack?.(item.id) ?? Promise.resolve()
+              : undefined
+          }
+          handleTrack={(updatedTrack) =>
+            item.updateTrack?.(item.id, updatedTrack) ?? Promise.resolve()
+          }
+        />
+      )}
+    </>
+  );
+}
+
+function addTrackMapItems(params: {
+  items: UnifiedTrackItem[];
+  keyPrefix: string;
+  sourceLabel: string;
+  trackMap: TrackMapByType;
+  updateTrack: (trackId: string, track: Partial<Track>) => Promise<void>;
+  deleteTrack: (trackId: string) => Promise<void>;
+}) {
+  const {
+    items,
+    keyPrefix,
+    sourceLabel,
+    trackMap,
+    updateTrack,
+    deleteTrack,
+  } = params;
+
+  allTrackTypes.forEach((trackType) => {
+    Object.entries(trackMap[trackType] ?? {}).forEach(([trackId, track]) => {
+      items.push({
+        key: `${keyPrefix}-${trackId}`,
+        id: trackId,
+        track,
+        sourceLabel,
+        allowEdit: true,
+        allowDelete: true,
+        updateTrack,
+        deleteTrack,
+      });
+    });
+  });
+}
+
+function sortTrackItems(a: UnifiedTrackItem, b: UnifiedTrackItem): number {
+  if (a.track.status !== b.track.status) {
+    return a.track.status === TrackStatus.Active ? -1 : 1;
+  }
+  return getCreatedTime(b.track) - getCreatedTime(a.track);
+}
+
+function getCreatedTime(track: Track): number {
+  return track.createdDate instanceof Date ? track.createdDate.getTime() : 0;
+}

--- a/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
+++ b/src/components/features/ProgressTrack/UnifiedTracksSection.tsx
@@ -31,7 +31,6 @@ import {
 } from "types/Track.type";
 import { EditOrCreateTrackDialog } from "./EditOrCreateTrackDialog";
 import { ProgressTrack } from "./ProgressTrack";
-import { TrackCreateScopeOption } from "./TrackCreateScopeField";
 import {
   getAvailableTrackTypes,
   getTrackTypeLabel,
@@ -65,11 +64,6 @@ const allTrackTypes: TrackSectionTracks[] = [
   TrackTypes.DelveSite,
   TrackTypes.SceneChallenge,
   TrackTypes.Clock,
-];
-
-const createScopeOptions: TrackCreateScopeOption[] = [
-  { value: "campaign", label: "Shared" },
-  { value: "character", label: "Character" },
 ];
 
 export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
@@ -148,6 +142,10 @@ export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
     mode === "campaign" || (isInCampaign && hasMultipleCharacters)
       ? "campaign"
       : "character";
+  const createScopeHelperText =
+    createSource === "campaign"
+      ? "Everyone in this campaign can see and use this track."
+      : "Only this character can see and use this track.";
 
   const items = useMemo(() => {
     const nextItems: UnifiedTrackItem[] = [];
@@ -360,13 +358,15 @@ export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
             open={!!createTrackType}
             handleClose={closeCreateDialog}
             shared={createSource === "campaign"}
-            createScopeLabel={canChooseCreateSource ? "Track owner" : undefined}
-            createScopeOptions={
-              canChooseCreateSource ? createScopeOptions : undefined
+            createScopeLabel={canChooseCreateSource ? "Shared" : undefined}
+            createScopeChecked={
+              canChooseCreateSource ? createSource === "campaign" : undefined
             }
-            createScopeValue={createSource}
-            onCreateScopeChange={(value) =>
-              setCreateSource(value as CreateSource)
+            createScopeHelperText={
+              canChooseCreateSource ? createScopeHelperText : undefined
+            }
+            onCreateScopeChange={(checked) =>
+              setCreateSource(checked ? "campaign" : "character")
             }
             onClock={handleAddTrack}
           />
@@ -376,13 +376,15 @@ export function UnifiedTracksSection(props: UnifiedTracksSectionProps) {
             handleClose={closeCreateDialog}
             trackType={createTrackType}
             trackTypeName={getTrackTypeLabel(createTrackType, isStarforged)}
-            createScopeLabel={canChooseCreateSource ? "Track owner" : undefined}
-            createScopeOptions={
-              canChooseCreateSource ? createScopeOptions : undefined
+            createScopeLabel={canChooseCreateSource ? "Shared" : undefined}
+            createScopeChecked={
+              canChooseCreateSource ? createSource === "campaign" : undefined
             }
-            createScopeValue={createSource}
-            onCreateScopeChange={(value) =>
-              setCreateSource(value as CreateSource)
+            createScopeHelperText={
+              canChooseCreateSource ? createScopeHelperText : undefined
+            }
+            onCreateScopeChange={(checked) =>
+              setCreateSource(checked ? "campaign" : "character")
             }
             handleTrack={handleAddTrack}
           />

--- a/src/components/features/ProgressTrack/index.ts
+++ b/src/components/features/ProgressTrack/index.ts
@@ -1,3 +1,4 @@
 export * from "./ProgressTrack";
 export * from "./ProgressTrackList";
 export * from "./EditOrCreateTrackDialog";
+export * from "./UnifiedTracksSection";

--- a/src/components/features/ProgressTrack/trackMoveIdSystemValues.ts
+++ b/src/components/features/ProgressTrack/trackMoveIdSystemValues.ts
@@ -1,0 +1,24 @@
+import { GAME_SYSTEMS, GameSystemChooser } from "types/GameSystems.type";
+import { ProgressTracks, TrackTypes } from "types/Track.type";
+
+export const trackMoveIdSystemValues: GameSystemChooser<{
+  [key in ProgressTracks | TrackTypes.SceneChallenge]: string;
+}> = {
+  [GAME_SYSTEMS.IRONSWORN]: {
+    [TrackTypes.Vow]: "move:classic/quest/fulfill_your_vow",
+    [TrackTypes.Journey]: "move:classic/adventure/reach_your_destination",
+    [TrackTypes.Fray]: "move:classic/combat/end_the_fight",
+    [TrackTypes.DelveSite]: "move:delve/delve/locate_your_objective",
+    [TrackTypes.SceneChallenge]: "",
+    [TrackTypes.BondProgress]: "",
+  },
+  [GAME_SYSTEMS.STARFORGED]: {
+    [TrackTypes.Vow]: "move:starforged/quest/fulfill_your_vow",
+    [TrackTypes.Journey]: "move:starforged/exploration/finish_an_expedition",
+    [TrackTypes.Fray]: "move:starforged/combat/take_decisive_action",
+    [TrackTypes.DelveSite]: "",
+    [TrackTypes.BondProgress]: "move:starforged/connection/forge_a_bond",
+    [TrackTypes.SceneChallenge]:
+      "move:starforged/scene_challenge/finish_the_scene",
+  },
+};

--- a/src/components/features/ProgressTrack/trackTypeLabels.ts
+++ b/src/components/features/ProgressTrack/trackTypeLabels.ts
@@ -1,0 +1,52 @@
+import { TrackSectionTracks, TrackTypes } from "types/Track.type";
+
+export interface TrackTypeAvailability {
+  isDelveEnabled: boolean;
+  isIronsworn: boolean;
+  isLodestarEnabled: boolean;
+  isStarforged: boolean;
+}
+
+export function getTrackTypeLabel(
+  trackType: TrackSectionTracks,
+  isStarforged: boolean
+): string {
+  switch (trackType) {
+    case TrackTypes.Fray:
+      return "Combat Track";
+    case TrackTypes.Vow:
+      return "Vow";
+    case TrackTypes.Journey:
+      return isStarforged ? "Expedition" : "Journey";
+    case TrackTypes.DelveSite:
+      return "Delve Site";
+    case TrackTypes.SceneChallenge:
+      return "Scene Challenge";
+    case TrackTypes.Clock:
+      return "Clock";
+  }
+}
+
+export function getAvailableTrackTypes(
+  availability: TrackTypeAvailability
+): TrackSectionTracks[] {
+  const { isDelveEnabled, isIronsworn, isLodestarEnabled, isStarforged } =
+    availability;
+
+  const trackTypes: TrackSectionTracks[] = [
+    TrackTypes.Vow,
+    TrackTypes.Fray,
+    TrackTypes.Journey,
+  ];
+
+  if (isIronsworn && isDelveEnabled) {
+    trackTypes.push(TrackTypes.DelveSite);
+  }
+  if (isStarforged || (isIronsworn && isLodestarEnabled)) {
+    trackTypes.push(TrackTypes.SceneChallenge);
+  }
+
+  trackTypes.push(TrackTypes.Clock);
+
+  return trackTypes;
+}

--- a/src/components/features/charactersAndCampaigns/Clocks/ClockDialog.tsx
+++ b/src/components/features/charactersAndCampaigns/Clocks/ClockDialog.tsx
@@ -16,6 +16,10 @@ import { DialogTitleWithCloseButton } from "components/shared/DialogTitleWithClo
 import { useState } from "react";
 import { Clock, TrackStatus, TrackTypes } from "types/Track.type";
 import { ClockCircle } from "./ClockCircle";
+import {
+  TrackCreateScopeField,
+  TrackCreateScopeOption,
+} from "components/features/ProgressTrack/TrackCreateScopeField";
 
 const segmentOptions = [4, 6, 8, 10];
 
@@ -25,10 +29,24 @@ export interface ClockDialogProps {
   initialClock?: Clock;
   onClock: (clock: Clock) => Promise<void>;
   shared?: boolean;
+  createScopeLabel?: string;
+  createScopeOptions?: TrackCreateScopeOption[];
+  createScopeValue?: string;
+  onCreateScopeChange?: (value: string) => void;
 }
 
 export function ClockDialog(props: ClockDialogProps) {
-  const { open, handleClose, initialClock, onClock, shared } = props;
+  const {
+    open,
+    handleClose,
+    initialClock,
+    onClock,
+    shared,
+    createScopeLabel,
+    createScopeOptions,
+    createScopeValue,
+    onCreateScopeChange,
+  } = props;
 
   const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(false);
@@ -110,6 +128,18 @@ export function ClockDialog(props: ClockDialogProps) {
             multiline
             minRows={3}
           />
+          {!initialClock &&
+            createScopeLabel &&
+            createScopeOptions &&
+            createScopeValue &&
+            onCreateScopeChange && (
+              <TrackCreateScopeField
+                label={createScopeLabel}
+                options={createScopeOptions}
+                value={createScopeValue}
+                onChange={onCreateScopeChange}
+              />
+            )}
           <Typography>Segments</Typography>
           <Box display={"flex"} flexWrap={"wrap"}>
             {segmentOptions.map((segmentOption) => (

--- a/src/components/features/charactersAndCampaigns/Clocks/ClockDialog.tsx
+++ b/src/components/features/charactersAndCampaigns/Clocks/ClockDialog.tsx
@@ -18,7 +18,6 @@ import { Clock, TrackStatus, TrackTypes } from "types/Track.type";
 import { ClockCircle } from "./ClockCircle";
 import {
   TrackCreateScopeField,
-  TrackCreateScopeOption,
 } from "components/features/ProgressTrack/TrackCreateScopeField";
 
 const segmentOptions = [4, 6, 8, 10];
@@ -30,9 +29,9 @@ export interface ClockDialogProps {
   onClock: (clock: Clock) => Promise<void>;
   shared?: boolean;
   createScopeLabel?: string;
-  createScopeOptions?: TrackCreateScopeOption[];
-  createScopeValue?: string;
-  onCreateScopeChange?: (value: string) => void;
+  createScopeChecked?: boolean;
+  createScopeHelperText?: string;
+  onCreateScopeChange?: (checked: boolean) => void;
 }
 
 export function ClockDialog(props: ClockDialogProps) {
@@ -43,8 +42,8 @@ export function ClockDialog(props: ClockDialogProps) {
     onClock,
     shared,
     createScopeLabel,
-    createScopeOptions,
-    createScopeValue,
+    createScopeChecked,
+    createScopeHelperText,
     onCreateScopeChange,
   } = props;
 
@@ -130,13 +129,13 @@ export function ClockDialog(props: ClockDialogProps) {
           />
           {!initialClock &&
             createScopeLabel &&
-            createScopeOptions &&
-            createScopeValue &&
+            createScopeHelperText &&
+            createScopeChecked !== undefined &&
             onCreateScopeChange && (
               <TrackCreateScopeField
                 label={createScopeLabel}
-                options={createScopeOptions}
-                value={createScopeValue}
+                checked={createScopeChecked}
+                helperText={createScopeHelperText}
                 onChange={onCreateScopeChange}
               />
             )}

--- a/src/components/features/charactersAndCampaigns/ExpansionSelector/ExpansionSelector.tsx
+++ b/src/components/features/charactersAndCampaigns/ExpansionSelector/ExpansionSelector.tsx
@@ -14,8 +14,6 @@ import { EmptyState } from "components/shared/EmptyState";
 import { IExpansionConfig, includedExpansions } from "data/rulesets";
 import { buildExpansionChanges } from "./expansionCascade";
 
-export { buildExpansionChanges } from "./expansionCascade";
-
 export interface ExpansionSelectorProps {
   enabledExpansionMap: Record<string, boolean>;
   toggleEnableExpansion: (changes: Record<string, boolean>) => void;

--- a/src/components/features/charactersAndCampaigns/ExpansionSelector/index.ts
+++ b/src/components/features/charactersAndCampaigns/ExpansionSelector/index.ts
@@ -1,1 +1,2 @@
 export * from "./ExpansionSelector";
+export * from "./expansionCascade";

--- a/src/pages/Campaign/CampaignPage/components/Tabs/TracksTab.tsx
+++ b/src/pages/Campaign/CampaignPage/components/Tabs/TracksTab.tsx
@@ -1,40 +1,16 @@
 import { Container, Grid, Stack } from "@mui/material";
 import { SectionHeading } from "components/shared/SectionHeading";
 import { Track } from "components/features/Track";
-import { TrackStatus, TrackTypes } from "types/Track.type";
-import {
-  ProgressTrack,
-  ProgressTrackList,
-} from "components/features/ProgressTrack";
+import { UnifiedTracksSection } from "components/features/ProgressTrack";
 import { useStore } from "stores/store";
-import { ClockSection } from "components/features/charactersAndCampaigns/Clocks/ClockSection";
-import { useGameSystem } from "hooks/useGameSystem";
-import { GAME_SYSTEMS } from "types/GameSystems.type";
 
 export function TracksTab() {
-  const isStarforged = useGameSystem().gameSystem === GAME_SYSTEMS.STARFORGED;
-  const isIronsworn = useGameSystem().gameSystem === GAME_SYSTEMS.IRONSWORN;
-  const isDelveEnabled = useStore((store) =>
-    store.rules.expansionIds.includes("delve")
-  );
-
   const conditionMeterRules = useStore((store) => store.rules.conditionMeters);
   const conditionMeterValues = useStore(
     (store) => store.campaigns.currentCampaign.currentCampaign?.conditionMeters
   );
   const updateCampaignConditionMeter = useStore(
     (store) => store.campaigns.currentCampaign.updateCampaignConditionMeter
-  );
-
-  const characterTracks = useStore(
-    (store) => store.campaigns.currentCampaign.characters.characterTracks
-  );
-  const characters = useStore(
-    (store) => store.campaigns.currentCampaign.characters.characterMap
-  );
-
-  const updateCharacterProgressTrack = useStore(
-    (store) => store.campaigns.currentCampaign.tracks.updateCharacterTrack
   );
 
   return (
@@ -62,81 +38,7 @@ export function TracksTab() {
         </Grid>
       </Container>
 
-      <div>
-        <ProgressTrackList
-          trackType={TrackTypes.Fray}
-          typeLabel={"Shared Combat Track"}
-          isCampaign
-        />
-        <ProgressTrackList
-          trackType={TrackTypes.Vow}
-          typeLabel={"Shared Vow"}
-          isCampaign
-        />
-        <ProgressTrackList
-          trackType={TrackTypes.Journey}
-          typeLabel={isStarforged ? "Shared Expedition" : "Shared Journey"}
-          isCampaign
-        />
-        {isIronsworn && isDelveEnabled && (
-          <ProgressTrackList
-            trackType={TrackTypes.DelveSite}
-            typeLabel={"Shared Delve Site"}
-            isCampaign
-          />
-        )}
-        {isStarforged && (
-          <ProgressTrackList
-            trackType={TrackTypes.SceneChallenge}
-            typeLabel={"Shared Scene Challenge"}
-            isCampaign
-          />
-        )}
-        {Object.keys(characterTracks).map((characterId) => (
-          <div key={characterId}>
-            {characters[characterId] &&
-              Object.keys(characterTracks[characterId]?.[TrackTypes.Vow] ?? {})
-                .length > 0 && (
-                <>
-                  <SectionHeading
-                    label={characters[characterId].name + "'s Vows"}
-                  />
-                  <Stack mt={2} spacing={4} mb={4} px={{ xs: 2, sm: 3 }}>
-                    {Object.keys(
-                      characterTracks[characterId]?.[TrackTypes.Vow] ?? {}
-                    ).map((trackId, index) => {
-                      const track =
-                        characterTracks[characterId][TrackTypes.Vow][trackId];
-                      return (
-                        <ProgressTrack
-                          key={index}
-                          status={track.status}
-                          trackType={TrackTypes.Vow}
-                          label={track.label}
-                          description={track.description}
-                          difficulty={track.difficulty}
-                          value={track.value}
-                          max={40}
-                          onValueChange={(value) =>
-                            updateCharacterProgressTrack(characterId, trackId, {
-                              value,
-                            })
-                          }
-                          onComplete={() =>
-                            updateCharacterProgressTrack(characterId, trackId, {
-                              status: TrackStatus.Completed,
-                            })
-                          }
-                        />
-                      );
-                    })}
-                  </Stack>
-                </>
-              )}
-          </div>
-        ))}
-      </div>
-      <ClockSection />
+      <UnifiedTracksSection mode={"campaign"} />
     </Stack>
   );
 }

--- a/src/pages/Character/CharacterSheetPage/Tabs/TracksSection/TracksSection.tsx
+++ b/src/pages/Character/CharacterSheetPage/Tabs/TracksSection/TracksSection.tsx
@@ -1,48 +1,12 @@
 import { Stack } from "@mui/material";
-import { ProgressTrackSection } from "../ProgressTrackSection";
-import { TrackTypes } from "types/Track.type";
-import { GAME_SYSTEMS } from "types/GameSystems.type";
-import { ClockSection } from "components/features/charactersAndCampaigns/Clocks/ClockSection";
-import { useGameSystem } from "hooks/useGameSystem";
+import { UnifiedTracksSection } from "components/features/ProgressTrack";
 import { SpecialTracks } from "./SpecialTracks";
-import { useStore } from "stores/store";
 
 export function TracksSection() {
-  const isStarforged = useGameSystem().gameSystem === GAME_SYSTEMS.STARFORGED;
-  const isIronsworn = useGameSystem().gameSystem === GAME_SYSTEMS.IRONSWORN;
-  const isDelveEnabled = useStore((store) =>
-    store.rules.expansionIds.includes("delve")
-  );
-  const isLodestarEnabled = useStore((store) =>
-    store.rules.expansionIds.includes("lodestar")
-  );
-
   return (
     <Stack spacing={2} sx={{ pb: 2 }}>
       <SpecialTracks />
-      <ProgressTrackSection type={TrackTypes.Fray} typeLabel={"Combat Track"} />
-      <ProgressTrackSection
-        type={TrackTypes.Vow}
-        typeLabel={"Vow"}
-        showPersonalIfInCampaign
-      />
-      <ProgressTrackSection
-        type={TrackTypes.Journey}
-        typeLabel={isStarforged ? "Expedition" : "Journey"}
-      />
-      {isIronsworn && isDelveEnabled && (
-        <ProgressTrackSection
-          type={TrackTypes.DelveSite}
-          typeLabel={"Delve Site"}
-        />
-      )}
-      {(isStarforged || (isIronsworn && isLodestarEnabled)) && (
-        <ProgressTrackSection
-          type={TrackTypes.SceneChallenge}
-          typeLabel={"Scene Challenge"}
-        />
-      )}
-      <ClockSection />
+      <UnifiedTracksSection mode={"character"} />
     </Stack>
   );
 }

--- a/src/stores/campaign/currentCampaign/characters/campaignCharacters.slice.ts
+++ b/src/stores/campaign/currentCampaign/characters/campaignCharacters.slice.ts
@@ -65,50 +65,52 @@ export const createCampaignCharactersSlice: CreateSliceType<
     };
   },
   listenToCampaignCharacterTracks: (characterIds: string[]) => {
-    const unsubscribes = characterIds.map((characterId) => {
-      return listenToProgressTracks(
-        undefined,
-        characterId,
-        TrackStatus.Active,
-        (tracks) => {
-          set((store) => {
-            if (
-              !store.campaigns.currentCampaign.characters.characterTracks[
-                characterId
-              ]
-            ) {
-              store.campaigns.currentCampaign.characters.characterTracks[
-                characterId
-              ] = {
-                [TrackTypes.Fray]: {},
-                [TrackTypes.Journey]: {},
-                [TrackTypes.Vow]: {},
-                [TrackTypes.DelveSite]: {},
-                [TrackTypes.SceneChallenge]: {},
-                [TrackTypes.Clock]: {},
-              };
-            }
-            Object.keys(tracks).forEach((trackId) => {
-              const track = tracks[trackId];
-              store.campaigns.currentCampaign.characters.characterTracks[
-                characterId
-              ][track.type][trackId] = track;
+    const unsubscribes = characterIds.flatMap((characterId) =>
+      [TrackStatus.Active, TrackStatus.Completed].map((status) =>
+        listenToProgressTracks(
+          undefined,
+          characterId,
+          status,
+          (tracks) => {
+            set((store) => {
+              if (
+                !store.campaigns.currentCampaign.characters.characterTracks[
+                  characterId
+                ]
+              ) {
+                store.campaigns.currentCampaign.characters.characterTracks[
+                  characterId
+                ] = {
+                  [TrackTypes.Fray]: {},
+                  [TrackTypes.Journey]: {},
+                  [TrackTypes.Vow]: {},
+                  [TrackTypes.DelveSite]: {},
+                  [TrackTypes.SceneChallenge]: {},
+                  [TrackTypes.Clock]: {},
+                };
+              }
+              Object.keys(tracks).forEach((trackId) => {
+                const track = tracks[trackId];
+                store.campaigns.currentCampaign.characters.characterTracks[
+                  characterId
+                ][track.type][trackId] = track;
+              });
             });
-          });
-        },
+          },
 
-        (trackId, type) => {
-          set((store) => {
-            delete store.campaigns.currentCampaign.characters.characterTracks[
-              characterId
-            ][type][trackId];
-          });
-        },
-        (error) => {
-          console.error(error);
-        }
-      );
-    });
+          (trackId, type) => {
+            set((store) => {
+              delete store.campaigns.currentCampaign.characters.characterTracks[
+                characterId
+              ][type][trackId];
+            });
+          },
+          (error) => {
+            console.error(error);
+          }
+        )
+      )
+    );
     return () => {
       unsubscribes.forEach((unsubscribe) => {
         unsubscribe && unsubscribe();


### PR DESCRIPTION
## Summary

Reworks the character and campaign Tracks tabs around a single mixed track list instead of separate sections by track type. The new unified section supports progress tracks, scene challenges, and clocks in one newest-first list, with source/type chips so shared and character-owned tracks stay readable.

## Details

- Adds an `Add Track` menu for the enabled track types for the current ruleset/expansions.
- Moves the Shared vs Character choice into the create dialogs for character sheets in campaigns, defaulting to Shared when the campaign has multiple characters.
- Folds campaign-member character tracks into the campaign Tracks tab list, including completed tracks when Show Completed is enabled.
- Keeps legacy/special tracks and experience above the unified progress/clock list.
- Cleans up lint blockers by moving exported helpers out of component files and removing an unused import.

## Validation

- `npx tsc --noEmit`
- `npm run lint`
- `npm test -- --run`
